### PR TITLE
refactor: lets avoid lazy create of default helm values and handle in…

### DIFF
--- a/pkg/cmd/helm/step_helm_stream.go
+++ b/pkg/cmd/helm/step_helm_stream.go
@@ -169,7 +169,6 @@ func (o *StreamOptions) Run() error {
 		if err != nil {
 			return errors.Wrapf(err, "failed to create values dir for chart %s", chartName)
 		}
-		ho.ValuesFile = filepath.Join(valuesDir, "template-values.yaml")
 
 		log.Logger().Infof("generating chart %s version %s to dir %s", chartName, version, chartOutput)
 

--- a/pkg/cmd/helm/step_helm_template_test.go
+++ b/pkg/cmd/helm/step_helm_template_test.go
@@ -9,8 +9,6 @@ import (
 	"github.com/jenkins-x/jx-gitops/pkg/fakes/fakegit"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"k8s.io/api/extensions/v1beta1"
-	"sigs.k8s.io/yaml"
 )
 
 func TestStepHelmTemplate(t *testing.T) {
@@ -25,7 +23,6 @@ func TestStepHelmTemplate(t *testing.T) {
 	o.OutDir = tmpDir
 	o.BatchMode = true
 	o.Gitter = fakegit.NewGitFakeClone()
-	o.ValuesFile = filepath.Join(tmpDir, "template-values.yaml")
 
 	err = o.Run()
 	require.NoError(t, err, "failed to run the command")
@@ -38,23 +35,4 @@ func TestStepHelmTemplate(t *testing.T) {
 	assert.FileExists(t, filepath.Join(templateDir, "deployment.yaml"))
 	assert.FileExists(t, filepath.Join(templateDir, "service.yaml"))
 
-	ingressFile := filepath.Join(templateDir, "ingress.yaml")
-	require.FileExists(t, ingressFile)
-
-	data, err := ioutil.ReadFile(ingressFile)
-	require.NoError(t, err, "failed to load YAML from %s", ingressFile)
-
-	ing := &v1beta1.Ingress{}
-	err = yaml.Unmarshal(data, ing)
-	require.NoError(t, err, "failed to parse YAML from %s", ingressFile)
-
-	require.Equal(t, 1, len(ing.Spec.TLS), "ing.Spec.TLS")
-	require.Equal(t, 1, len(ing.Spec.Rules), "ing.Spec.Rules")
-
-	tls := ing.Spec.TLS[0]
-	expectedHost := "mychart.cluster.local"
-	assert.Equal(t, []string{expectedHost}, tls.Hosts, "ing.Spec.TLS[0].Hosts")
-
-	rule := ing.Spec.Rules[0]
-	assert.Equal(t, expectedHost, rule.Host, "ing.Spec.Rules[0].Host")
 }


### PR DESCRIPTION
… version stream instead, they may not always be needed for every helm chart we convert.

Also changed the values CLI flag to accept a string array of helm values.yaml files and pass them straight onto helm template args.