### PR TITLE
fix: better defaulting of the namespace

### DIFF
--- a/pkg/cmd/jx_apps/test_data/input/jx-requirements.yml
+++ b/pkg/cmd/jx_apps/test_data/input/jx-requirements.yml
@@ -1,0 +1,5 @@
+cluster:
+  namespace: jx
+versionStream:
+  ref: master
+  url: https://github.com/jenkins-x/jxr-versions.git


### PR DESCRIPTION
if there's none in the jx-apps.yml lets use jx-requirements.yml or a CLI argument default