### PR TITLE
fix: jx apps handle local repo prefixes

### DIFF
--- a/pkg/cmd/jx_apps/step_jx_apps_template.go
+++ b/pkg/cmd/jx_apps/step_jx_apps_template.go
@@ -159,12 +159,22 @@ func (o *JxAppsTemplateOptions) Run() error {
 		prefix := parts[0]
 		chartName := parts[1]
 
+		// lets resolve the chart prefix from a local repository from the file or from a
+		// prefix in the versions stream
+		if repository == "" && prefix != "" {
+			for _, r := range appsCfg.Repositories {
+				if r.Name == prefix {
+					repository = r.URL
+				}
+			}
+		}
 		if repository == "" && prefix != "" {
 			repository, err = o.matchPrefix(prefix)
 			if err != nil {
 				return errors.Wrapf(err, "failed to match prefix %s with repositories from versionstream %s", prefix, o.VersionStreamURL)
 			}
-		} else {
+		}
+		if repository == "" && prefix != "" {
 			return errors.Wrapf(err, "failed to find repository URL, not defined in jx-apps.yml or versionstream %s", o.VersionStreamURL)
 		}
 

--- a/pkg/cmd/jx_apps/step_jx_apps_template_test.go
+++ b/pkg/cmd/jx_apps/step_jx_apps_template_test.go
@@ -51,6 +51,7 @@ func TestStepJxAppsTemplate(t *testing.T) {
 
 	t.Logf("generated templates to %s", templateDir)
 
+	assert.FileExists(t, filepath.Join(templateDir, "jx", "bucketrepo", "deployment.yaml"))
 	assert.FileExists(t, filepath.Join(templateDir, "foo", "external-dns", "deployment.yaml"))
 	assert.FileExists(t, filepath.Join(templateDir, "foo", "external-dns", "service.yaml"))
 	assert.FileExists(t, filepath.Join(templateDir, "foo", "external-dns", "clusterrolebinding.yaml"))

--- a/pkg/cmd/jx_apps/test_data/input/jx-apps.yml
+++ b/pkg/cmd/jx_apps/test_data/input/jx-apps.yml
@@ -1,24 +1,12 @@
 apps:
-  - name: jenkins-x/jxboot-helmfile-resources
-  - name: bitnami/external-dns
-    namespace: foo
-  - name: jenkins-x/tekton
-  - name: external-secrets/kubernetes-external-secrets
-    namespace: external-secrets
-#  - name: gsm-controller
-#    phase: apps
-#    repository: https://storage.googleapis.com/jenkinsxio-labs/charts
-#  - name: feature-infra-secrets
-#    phase: apps
-#    repository: gs://jenkinsxio-labs-private/charts
-#  - name: repositories
-#    repository: ".."
-#  - name: jx-app-replicator
-#    repository: https://storage.googleapis.com/chartmuseum.jenkins-x.io
-#    version: 1.0.16
-#    phase: apps
-#  - name: kuberhealthy
-#    repository: https://comcast.github.io/kuberhealthy/helm-repos
-#    version: 2.1.0
-#    phase: apps
-#    namespace: kuberhealthy
+- name: jenkins-x/tekton
+- name: jenkins-x/jxboot-helmfile-resources
+- name: bitnami/external-dns
+  namespace: foo
+- name: external-secrets/kubernetes-external-secrets
+  namespace: external-secrets
+# test using a local repo prefix and URL
+- name: doesnotexist/bucketrepo
+repositories:
+- name: doesnotexist
+  url: https://storage.googleapis.com/chartmuseum.jenkins-x.io


### PR DESCRIPTION
for remote environments; handle repos in `jx-apps.yml` files which are not defined in the version stream along with a test case