### PR TITLE
fix: lazily create Namespace resources

### DIFF
--- a/pkg/cmd/namespace/namespace.go
+++ b/pkg/cmd/namespace/namespace.go
@@ -77,7 +77,7 @@ func (o *Options) Run() error {
 	ns := o.Namespace
 	if o.ClusterDir == "" {
 		// lets navigate relative to the namespaces dir
-		o.ClusterDir = filepath.Join(o.Dir, "..", "clusters", "namespaces")
+		o.ClusterDir = filepath.Join(o.Dir, "..", "cluster", "namespaces")
 		err := os.MkdirAll(o.ClusterDir, files.DefaultDirWritePermissions)
 		if err != nil {
 			return errors.Wrapf(err, "failed to create cluster namespaces dir %s", o.ClusterDir)

--- a/pkg/cmd/namespace/namespace_test.go
+++ b/pkg/cmd/namespace/namespace_test.go
@@ -135,7 +135,7 @@ func TestNamespaceDirMode(t *testing.T) {
 	})
 	require.NoError(t, err, "failed to find results")
 
-	clusterNamespacesDir := filepath.Join(rootTmpDir, "clusters", "namespaces")
+	clusterNamespacesDir := filepath.Join(rootTmpDir, "cluster", "namespaces")
 	assert.DirExists(t, clusterNamespacesDir, "should have created folder for the lazy created Namespace resources")
 
 	for k, v := range found {


### PR DESCRIPTION
to ensure we always have a Namespace resource created for all the namespaces used in the resources