### PR TITLE
fix: lets put cluster resources into a sub dir

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/jenkins-x/jx-helpers/v3 v3.0.104
 	github.com/jenkins-x/jx-kube-client/v3 v3.0.2
 	github.com/jenkins-x/jx-logging/v3 v3.0.3
-	github.com/jenkins-x/lighthouse-client v0.0.103
+	github.com/jenkins-x/lighthouse-client v0.0.104
 	github.com/pborman/uuid v1.2.0
 	github.com/pkg/errors v0.9.1
 	github.com/roboll/helmfile v0.138.4

--- a/go.sum
+++ b/go.sum
@@ -1025,8 +1025,8 @@ github.com/jenkins-x/jx-kube-client/v3 v3.0.2 h1:sJs6FaIwycDYwE4UsA7j9tpdXOxXEta
 github.com/jenkins-x/jx-kube-client/v3 v3.0.2/go.mod h1:C/mKnCT5wvolX61eLKJVBNev9sqnkGNpi4skTQ1Gr3Q=
 github.com/jenkins-x/jx-logging/v3 v3.0.3 h1:sVACbwiKuaDFYPfJeVAU10MJI4DA6LcH1RqJKwfNozc=
 github.com/jenkins-x/jx-logging/v3 v3.0.3/go.mod h1:Vp2ER2SYgGhAgEEHlLwfi2ZB54tz6ya1qExq0A4CKMI=
-github.com/jenkins-x/lighthouse-client v0.0.103 h1:Kk952lHM4oKsN5pNKyKAlpPbv5Fs8bI32qyFLbWK5eg=
-github.com/jenkins-x/lighthouse-client v0.0.103/go.mod h1:518u7LURJtPmWDsRsuGAHjRCd5NiZAd6uhvx4rwCUo8=
+github.com/jenkins-x/lighthouse-client v0.0.104 h1:2lm29TkRp1C7ZOVWgxn65nNDqsxUg2aow21sCwg75zg=
+github.com/jenkins-x/lighthouse-client v0.0.104/go.mod h1:F4GMkoxONpQ+uQuaFiGnB9K1hbOUzJgwgtb5xsTaifQ=
 github.com/jenkins-x/logrus-stackdriver-formatter v0.2.3 h1:NuRWKUPCEX1wKlXA8ZYSG28qGKd41R7BK11YDQkPwqo=
 github.com/jenkins-x/logrus-stackdriver-formatter v0.2.3/go.mod h1:litPp7VZWDRCl8LvXuqGngy+65kkg/+T23TgFnDmfTk=
 github.com/jessevdk/go-flags v1.4.0 h1:4IU2WS7AumrZ/40jfhf4QVDMsQwqA7VEHozFRrGARJA=

--- a/pkg/cmd/helmfile/move/move.go
+++ b/pkg/cmd/helmfile/move/move.go
@@ -52,6 +52,7 @@ type Options struct {
 	DirIncludesReleaseName       bool
 	ClusterDir                   string
 	ClusterNamespacesDir         string
+	ClusterResourcesDir          string
 	CustomResourceDefinitionsDir string
 	NamespacesDir                string
 	SingleNamespace              string
@@ -88,6 +89,13 @@ func (o *Options) Run() error {
 	}
 	if o.NamespacesDir == "" {
 		o.NamespacesDir = filepath.Join(o.OutputDir, "namespaces")
+	}
+	if o.ClusterResourcesDir == "" {
+		o.ClusterResourcesDir = filepath.Join(o.ClusterDir, "resources")
+		err := os.MkdirAll(o.ClusterResourcesDir, files.DefaultDirWritePermissions)
+		if err != nil {
+			return errors.Wrapf(err, "failed to create cluster resources dir %s", o.ClusterResourcesDir)
+		}
 	}
 	if o.ClusterNamespacesDir == "" {
 		o.ClusterNamespacesDir = filepath.Join(o.ClusterDir, "namespaces")
@@ -252,7 +260,7 @@ func (o *Options) moveFilesToClusterOrNamespacesFolder(dir string, ns string, re
 		}
 
 		kind := kyamls.GetKind(node, path)
-		outDir := filepath.Join(o.ClusterDir, ns, pathName)
+		outDir := filepath.Join(o.ClusterResourcesDir, ns, pathName)
 
 		if kyamls.IsCustomResourceDefinition(kind) {
 			outDir = filepath.Join(o.CustomResourceDefinitionsDir, ns, pathName)

--- a/pkg/cmd/helmfile/move/move_test.go
+++ b/pkg/cmd/helmfile/move/move_test.go
@@ -24,7 +24,7 @@ func TestUpdateNamespaceInYamlFiles(t *testing.T) {
 			hasReleaseName: false,
 			expectedFiles: []string{
 				"customresourcedefinitions/jx/lighthouse/lighthousejobs.lighthouse.jenkins.io-crd.yaml",
-				"cluster/nginx/nginx-ingress/nginx-ingress-clusterrole.yaml",
+				"cluster/resources/nginx/nginx-ingress/nginx-ingress-clusterrole.yaml",
 				"namespaces/jx/lighthouse/lighthouse-foghorn-deploy.yaml",
 			},
 		},
@@ -33,10 +33,10 @@ func TestUpdateNamespaceInYamlFiles(t *testing.T) {
 			hasReleaseName: true,
 			expectedFiles: []string{
 				"customresourcedefinitions/jx/lighthouse/lighthousejobs.lighthouse.jenkins.io-crd.yaml",
-				"cluster/nginx/nginx-ingress/nginx-ingress-clusterrole.yaml",
+				"cluster/resources/nginx/nginx-ingress/nginx-ingress-clusterrole.yaml",
 				"namespaces/jx/lighthouse/lighthouse-foghorn-deploy.yaml",
 				"customresourcedefinitions/jx/lighthouse-2/lighthousejobs.lighthouse.jenkins.io-crd.yaml",
-				"cluster/nginx/nginx-ingress-2/nginx-ingress-clusterrole.yaml",
+				"cluster/resources/nginx/nginx-ingress-2/nginx-ingress-clusterrole.yaml",
 				"namespaces/jx/lighthouse-2/lighthouse-foghorn-deploy.yaml",
 				"namespaces/jx/chart-release/example.yaml",
 			},


### PR DESCRIPTION
so that we can more easily process namespace resources differently to
non-namespace cluster resources (e.g. to avoid pruning Namespaces by
default)