### PR TITLE
fix: lets log a warning if a Chart.yaml is invalid

### DIFF
--- a/pkg/cmd/helmfile/report/report.go
+++ b/pkg/cmd/helmfile/report/report.go
@@ -353,7 +353,9 @@ func (o *Options) enrichChartMetadata(i *releasereport.ReleaseInfo, repo *state.
 	m := &chart.Metadata{}
 	err = yaml.UnmarshalStrict([]byte(text), &m)
 	if err != nil {
-		return errors.Wrapf(err, "failed to parse the output of %s got results: %s", c.CLI(), text)
+		log.Logger().Warnf("failed to parse the output of %s which failed with: %v", c.CLI(), err)
+		log.Logger().Infof("output Chart YAML:\n%s", text)
+		return nil
 	}
 	i.Metadata = *m
 	i.Name = name


### PR DESCRIPTION
rather than fail the boot job