### PR TITLE
fix: warn instead of fail if 'jx gitops variables' is run in a folder without git

### DIFF
--- a/pkg/cmd/variables/variables.go
+++ b/pkg/cmd/variables/variables.go
@@ -474,7 +474,7 @@ func (o *Options) GetGitBranch() (string, error) {
 		var err error
 		o.GitBranch, err = gitclient.Branch(o.GitClient, o.Dir)
 		if err != nil {
-			return o.GitBranch, errors.Wrapf(err, "failed to ")
+			log.Logger().Warnf("failed to get the current git branch as probably not in a git clone directory, so cannot create the GIT_BRANCH. (%s)", err.Error())
 		}
 	}
 	return o.GitBranch, nil


### PR DESCRIPTION
Ref: https://kubernetes.slack.com/archives/C9MBGQJRH/p1620116491200400