### PR TITLE
fix: return empty string instead of the error message if not in a git directory

### DIFF
--- a/pkg/cmd/variables/variables.go
+++ b/pkg/cmd/variables/variables.go
@@ -475,6 +475,7 @@ func (o *Options) GetGitBranch() (string, error) {
 		o.GitBranch, err = gitclient.Branch(o.GitClient, o.Dir)
 		if err != nil {
 			log.Logger().Warnf("failed to get the current git branch as probably not in a git clone directory, so cannot create the GIT_BRANCH. (%s)", err.Error())
+			o.GitBranch = ""
 		}
 	}
 	return o.GitBranch, nil


### PR DESCRIPTION
Fixes the current GIT\_BRANCH content since the merge of [this PR](https://github.com/jenkins-x-plugins/jx-gitops/pull/749):

> GIT\_BRANCH=fatal: not a git repository (or any parent up to mount point /)