### PR TITLE
chore: Move submitted doucmentation changes frox jx-docs to jx-gitops source code

### DIFF
--- a/pkg/cmd/git/clone/clone.go
+++ b/pkg/cmd/git/clone/clone.go
@@ -21,8 +21,11 @@ var (
 	info = termcolor.ColorInfo
 
 	cmdLong = templates.LongDesc(`
-		Clones the cluster git repository using the URL, git user and token from the Secret
+	Clones the cluster git repository from the URL provided to the jx-git-operator watching the said repository, and
+	authenticating as git user with token provided by jx-boot secret, also provided by jx-git-operator installation.
 
+	Effectively this command runs jx gitops git setup before proceeding to simply clone the repository into either the
+	folder passed in via --clone-dir or into the ./setup directory.
 `)
 
 	cmdExample = templates.Examples(`
@@ -50,7 +53,7 @@ func NewCmdGitClone() (*cobra.Command, *Options) {
 			helper.CheckErr(err)
 		},
 	}
-	cmd.Flags().StringVarP(&o.CloneDir, "clone-dir", "", "", "the directory to clone the repository to")
+	cmd.Flags().StringVarP(&o.CloneDir, "clone-dir", "", "", "the directory to clone the repository to. Default value used is ./source relative to the directory in which the command is running")
 	o.Options.AddFlags(cmd)
 	return cmd, o
 }

--- a/pkg/cmd/git/get/get.go
+++ b/pkg/cmd/git/get/get.go
@@ -27,7 +27,21 @@ import (
 
 var (
 	cmdLong = templates.LongDesc(`
-		Gets a file from a git repository or environment git repository
+		Gets a file from the specified git repository or the git repository described in specified JX Environment resource.
+
+		Copies a file specified by --file flag from a Git repository into local file system. The repository from which the
+		file is read is either the one specified via command line flags or the one defined as the target repository of the
+		Jenkins X Environment object, whose name too can be passed in via CLI flags.
+
+		In case that repository is read out from the environment, then if we are running in Kubernetes cluster the Environment
+		object is searched for either in the namespace defined by the current kubeconfig context (if command is executed
+		locally) or is searched for in the namespace of the Pod on which the command is being executed.
+
+		In case that command is not executed in Kubernetes and the repository has not been set via command line flags, then the
+		repository from which file is read needs to be configured in environment variable: JX_ENVIRONMENT_GIT_URL.
+
+		The file is either copied to the path specified by the command line flag --to or is written under the same path from
+		which it was read into the current working directory.
 `)
 
 	cmdExample = templates.Examples(`

--- a/pkg/cmd/git/merge/merge.go
+++ b/pkg/cmd/git/merge/merge.go
@@ -20,7 +20,19 @@ import (
 
 var (
 	cmdLong = templates.LongDesc(`
-		Merge a number of SHAs into the HEAD of the main branch
+		Merge a number of SHAs into the HEAD of the main branch.
+
+		This command merges a list of commits into a specified branch. If the branch does not exist among local branches, then
+		it is first created.
+
+		If both --pull-refs and --sha flags are specified then only those commits specified by --sha are merged into the
+		base branch.
+
+		If --include-comment or --exclude-comment flags are specified, then --pull-number flag needs to be set as well.
+		If only one of --include-comment or --exclude-comment, then only that one is used to filter commits while other is
+		ignored. If both are specified, then only those commits which satisfy --include-comment and do not satisfy the
+		--exclude-comment regex are added. Only those commits which are reachable by from pull request and are not reachable
+		by base branch are included to be merged into the base branch.
 `)
 
 	cmdExample = templates.Examples(`

--- a/pkg/cmd/git/setup/setup.go
+++ b/pkg/cmd/git/setup/setup.go
@@ -34,9 +34,40 @@ var (
 	info = termcolor.ColorInfo
 
 	cmdLong = templates.LongDesc(`
-		Sets up git to ensure the git user name and email is setup.
+		Sets up git to ensure the git user name and email is setup. This is typically used in a pipeline to ensure git can do commits.
 
-This is typically used in a pipeline to ensure git can do commits.
+		The jx gitops git setup command ensures that we can authenticate with configured Git server by configuring the local
+		credentials file in the home directory. This command tries to ensure the following things:
+
+		- The user can be authenticated with Git provider (for example Github)
+		- An email is associated with each automated commit message
+
+		These credentials are written to ${HOME}/git/credentials file, where the ${HOME} directory is determined as:
+
+		- value stored in XGD_CONFIG_HOME environment variable or
+		- value stored in HOME environment variable or
+		- value stored in USERPROFILE environment variable or
+		- as current directory ./
+
+		The credentials are determined by reading out the jx-requirements.yaml from the cluster repository and jx-boot
+		Secret resource provisioned together with jx-git-operator in your Kubernetes namespace.
+
+		The Git username and email are preferentially determined from PipelineUser field from jx-requirements.yaml, but if
+		they are not available there then default email address jenkins-x@googlegroups.com is used . If the username could not be determined
+		from jx-requirements.yaml, then it is determined from:
+
+		- GIT_USERNAME environment variable or
+		- GITHUB_ACTOR environment variable
+		- In case that we are running in Kubernetes cluster from "username" field of the "jx-boot" Secret provisioned with
+		"jx-git-operator"
+
+		The password for Github user (or a token for the robot account, depending on which you configued) is determined in
+		similar fashion. Namely the token is first determined from environment variable GITHUB_TOKEN, but if that fails, then
+		further determination is dependent on execution environment of the command. Namely if it is running within Github
+		actions, then the GITHUB_TOKEN environment variable is our last stop. Otherwise if the command is executed within
+		Kubernetes cluster, then the secret is determined by reading the password field of the "jx-boot" Secret provisioned
+		with the "jx-git-operator".
+
 `)
 
 	cmdExample = templates.Examples(`
@@ -87,8 +118,8 @@ func (o *Options) AddFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVarP(&o.Dir, "dir", "d", "", "the directory to run the git setup command from")
 	cmd.Flags().StringVarP(&o.UserName, "name", "n", "", "the git user name to use if one is not setup")
 	cmd.Flags().StringVarP(&o.Password, "password", "", "", "the git password/token to use. if not specified it is detected from the git operator Secret")
-	cmd.Flags().StringVarP(&o.UserEmail, "email", "e", "", "the git user email to use if one is not setup")
-	cmd.Flags().StringVarP(&o.GitProviderURL, "git-provider", "", "", "the git provider URL. If not specified its detected from the git operator Secret or defaults to https://github.com")
+	cmd.Flags().StringVarP(&o.UserEmail, "email", "e", "", "the git user email to use if one is not setup. Default value is jenkins-x@googlegroups.com, if none other is provided")
+	cmd.Flags().StringVarP(&o.GitProviderURL, "git-provider", "", "", "the git provider URL. If not specified its detected from the git operator jx-boot Secret or defaults to https://github.com")
 	cmd.Flags().StringVarP(&o.OutputFile, "credentials-file", "", "", "The destination of the git credentials file to generate. If not specified uses $XDG_CONFIG_HOME/git/credentials or $HOME/git/credentials")
 	cmd.Flags().StringVarP(&o.OperatorNamespace, "operator-namespace", "", "jx-git-operator", "the namespace used by the git operator to find the secret for the git repository if running in cluster")
 	cmd.Flags().StringVarP(&o.Namespace, "namespace", "", "", "the namespace used to find the git operator secret for the git repository if running in cluster. Defaults to the current namespace")


### PR DESCRIPTION
This documentation has already been contributed [here](https://github.com/jenkins-x/jx-docs/pull/3335) but it was noted that it was misplaced. Here I have moved the documentation back into the source code.

