### PR TITLE
fix: ensure the registry name is in lowercase

### DIFF
--- a/pkg/cmd/variables/variables.go
+++ b/pkg/cmd/variables/variables.go
@@ -439,7 +439,7 @@ func (o *Options) dockerRegistry() (string, error) {
 	if answer == "" {
 		answer = o.ConfigMapData["DOCKER_REGISTRY"]
 	}
-	return answer, nil
+	return strings.ToLower(answer), nil
 }
 
 func (o *Options) pushContainerRegistry() (string, error) {

--- a/pkg/cmd/variables/variables_test.go
+++ b/pkg/cmd/variables/variables_test.go
@@ -101,7 +101,7 @@ func TestCmdVariables(t *testing.T) {
 					Namespace: ns,
 				},
 				Data: map[string]string{
-					"docker.registry":         "my-registry.com",
+					"docker.registry":         "my-Registry.com",
 					"kaniko.flags":            "cheese",
 					"PUSH_CONTAINER_REGISTRY": "localhost:5000",
 				},


### PR DESCRIPTION
Azure ACR and AWS ECR must have their name in lowercase, and since [putting the registry name in lowercase in jx-requirements](https://github.com/jenkins-x-terraform/terraform-jx-azure/pull/9) isn't enought, it's also put in lowercase in variables.sh, to avoid error at pipelines build time.

https://docs.microsoft.com/en-us/azure/container-registry/container-registry-faq#az-acr-login-succeeds-but-docker-fails-with-error-unauthorized-authentication-required
https://aws.amazon.com/en/ecr/ (see the first note)

