### PR TITLE
fix: compatible regen-phase with gitlab

### DIFF
--- a/pkg/cmd/apply/apply.go
+++ b/pkg/cmd/apply/apply.go
@@ -99,7 +99,7 @@ func (o *Options) Run() error {
 	}
 
 	regen := true
-	if strings.HasPrefix(lastCommitMessage, "Merge pull request") {
+	if strings.HasPrefix(lastCommitMessage, "Merge pull request") || strings.HasPrefix(lastCommitMessage, "Merge branch") {
 		log.Logger().Infof("last commit was a merge pull request so not regenerating")
 		regen = false
 	}


### PR DESCRIPTION
In gitlab， merge request message default like
```
Merge branch 'pr-cb3d0312-bdb0-496a-90ba-7e6f59d7afc7' into 'master'
chore: promote xxxxxxx to version 1.1.19

See merge request !500
```

This will cause the region run in pullrequst to be rerun after merge。