### PR TITLE
chore: add helm repos before helm build

### DIFF
--- a/pkg/chart/chart.go
+++ b/pkg/chart/chart.go
@@ -1,0 +1,11 @@
+package chart
+
+type Chart struct {
+	Dependencies []*ChartDependencies `json:"dependencies"`
+}
+
+type ChartDependencies struct {
+	Name       string `json:"name"`
+	Version    string `json:"version"`
+	Repository string `json:"repository"`
+}


### PR DESCRIPTION
This PR adds any repositories declared under `dependencies` in _Chart.yaml_ with `helm repo add` before running `helm repo build`. Without it the _promote-helm-release_ fails with a similar error when dependencies are needed:
```
no repository definition for https://charts.bitnami.com/bitnami. Please add the missing repos via 'helm repo add'
```

This PR only works with the v2 spec of _Chart.yaml_. If having a separate _requirements.yaml_ for dependencies, this PR won't have any effect.