### PR TITLE
fix: allow rename to work with templated yaml

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/jenkins-x/jx-helpers/v3 v3.0.126
 	github.com/jenkins-x/jx-kube-client/v3 v3.0.2
 	github.com/jenkins-x/jx-logging/v3 v3.0.6
-	github.com/jenkins-x/lighthouse-client v0.0.217
+	github.com/jenkins-x/lighthouse-client v0.0.225
 	github.com/pborman/uuid v1.2.0
 	github.com/pkg/errors v0.9.1
 	github.com/roboll/helmfile v0.139.0

--- a/go.sum
+++ b/go.sum
@@ -796,8 +796,8 @@ github.com/jenkins-x/jx-kube-client/v3 v3.0.2/go.mod h1:C/mKnCT5wvolX61eLKJVBNev
 github.com/jenkins-x/jx-logging/v3 v3.0.3/go.mod h1:Vp2ER2SYgGhAgEEHlLwfi2ZB54tz6ya1qExq0A4CKMI=
 github.com/jenkins-x/jx-logging/v3 v3.0.6 h1:rXiLYK7WuliCtujKkeU77fnSTJRDSIgbIk7PG4fnZGc=
 github.com/jenkins-x/jx-logging/v3 v3.0.6/go.mod h1:Vp2ER2SYgGhAgEEHlLwfi2ZB54tz6ya1qExq0A4CKMI=
-github.com/jenkins-x/lighthouse-client v0.0.217 h1:IJBqcYTrxwjRfNi4mh1S15LtlAVGFocV5BVCQjQLG3g=
-github.com/jenkins-x/lighthouse-client v0.0.217/go.mod h1:QY3G09HIYwENkwycN5MfE8jM790Xt6/sqUr8KkZhxOA=
+github.com/jenkins-x/lighthouse-client v0.0.225 h1:77g/saK8iDR6W/wFsTPvP12v48dwE4quziIn5I0GHmQ=
+github.com/jenkins-x/lighthouse-client v0.0.225/go.mod h1:QY3G09HIYwENkwycN5MfE8jM790Xt6/sqUr8KkZhxOA=
 github.com/jenkins-x/logrus-stackdriver-formatter v0.2.3 h1:NuRWKUPCEX1wKlXA8ZYSG28qGKd41R7BK11YDQkPwqo=
 github.com/jenkins-x/logrus-stackdriver-formatter v0.2.3/go.mod h1:litPp7VZWDRCl8LvXuqGngy+65kkg/+T23TgFnDmfTk=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=

--- a/pkg/cmd/rename/rename_test.go
+++ b/pkg/cmd/rename/rename_test.go
@@ -35,6 +35,7 @@ func TestRenameYamlFiles(t *testing.T) {
 		"cheese-svc.yaml",
 		"cheese-ksvc.yaml",
 		"foo-bar-cm.yaml",
+		"feature-flags2-cm.yaml",
 	}
 
 	for _, f := range expectedFiles {

--- a/pkg/cmd/rename/test_data/resource-with-helm-templates.yaml
+++ b/pkg/cmd/rename/test_data/resource-with-helm-templates.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+data:
+  disable-affinity-assistant: "false"
+  disable-creds-init: "false"
+  disable-home-env-overwrite: "true"
+  disable-working-directory-overwrite: "true"
+  enable-api-fields: stable
+  enable-custom-tasks: "false"
+  enable-tekton-oci-bundles: "false"
+  require-git-ssh-secret-known-hosts: "false"
+  running-in-environment-with-injected-sidecars: "true"
+  {{- if .Values.featureFlags -}}{{- toYaml .Values.featureFlags | nindent 2 }}{{ end }}
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/part-of: tekton-pipelines
+  name: feature-flags2
+  namespace: tekton-pipelines


### PR DESCRIPTION
so that it can ignore the to template lines starting with `{{` when parsing
to find the resource name, kind, namespace