### PR TITLE
fix: Default username to user not owner

### DIFF
--- a/pkg/cmd/helm/release/release.go
+++ b/pkg/cmd/helm/release/release.go
@@ -391,7 +391,7 @@ func (o *Options) ChartPageRegistry(repoURL, chartDir, name string) error {
 				o.RepositoryPassword = discover.GitToken
 			}
 			if o.RepositoryUsername == "" {
-				o.RepositoryUsername = discover.Owner
+				o.RepositoryUsername = discover.ScmClient.Username
 			}
 			if o.GithubPagesURL == "" {
 				o.GithubPagesURL = fmt.Sprintf("https://%s.github.io/%s/", discover.Owner, discover.Repository)


### PR DESCRIPTION
When using github pages to publish the helm chart the username to github is now defaults to the owner (organisation) instead of the actual name of the user. This fixes that.