### PR TITLE
chore(deps): Upgrade helm and helmfile

### DIFF
--- a/pkg/plugins/versions.go
+++ b/pkg/plugins/versions.go
@@ -19,10 +19,10 @@ const (
 	KappPluginName = "kapp"
 
 	// HelmVersion the default version of helm to use
-	HelmVersion = "3.6.2"
+	HelmVersion = "3.7.2"
 
 	// HelmfileVersion the default version of helmfile to use
-	HelmfileVersion = "0.139.9"
+	HelmfileVersion = "0.143.0"
 
 	// KptVersion the default version of kpt to use
 	KptVersion = "0.37.0"


### PR DESCRIPTION
The main reason for this PR is that in the last version of helmfile you can specify the value of .Capabilities.KubeVersion in template mode, which is necessary get some helm charts rendered correctly.