### PR TITLE
fix: backdate version to increase kubernetes version compatability

### DIFF
--- a/pkg/plugins/versions.go
+++ b/pkg/plugins/versions.go
@@ -28,7 +28,7 @@ const (
 	KptVersion = "0.37.0"
 
 	// KubectlVersion the default version of kpt to use
-	KubectlVersion = "1.22.5"
+	KubectlVersion = "1.21.0"
 
 	// KappVersion the default version of kapp to use
 	KappVersion = "0.35.1-cmfork"


### PR DESCRIPTION
Seen issues with kubernetes version 1.20 with the current version, so backdating to allow users to have more choice in their selection of k8s versions. As we shouldn't be dictating which version of k8s our users are on.