### PR TITLE
refactor: use T.TempDir to create temporary test directory

### DIFF
--- a/pkg/cmd/annotate/annotate_test.go
+++ b/pkg/cmd/annotate/annotate_test.go
@@ -25,8 +25,7 @@ func TestUpdateAnnotatesInYamlFiles(t *testing.T) {
 	}
 
 	for _, args := range argTests {
-		tmpDir, err := ioutil.TempDir("", "")
-		require.NoError(t, err, "could not create temp dir")
+		tmpDir := t.TempDir()
 
 		type testCase struct {
 			SourceFile   string

--- a/pkg/cmd/git/clone/clone_test.go
+++ b/pkg/cmd/git/clone/clone_test.go
@@ -1,7 +1,6 @@
 package clone_test
 
 import (
-	"io/ioutil"
 	"path/filepath"
 	"testing"
 
@@ -39,14 +38,13 @@ func TestGitClone(t *testing.T) {
 			},
 		},
 	)
-	tmpDir, err := ioutil.TempDir("", "")
-	require.NoError(t, err, "failed to create temp flie")
+	tmpDir := t.TempDir()
 	o.OutputFile = filepath.Join(tmpDir, "git-credentials")
 	o.Dir = tmpDir
 
 	t.Logf("creating git credentials file %s", o.OutputFile)
 
-	err = o.Run()
+	err := o.Run()
 	require.NoError(t, err, "failed to run git setup")
 
 	runner.ExpectResults(t,

--- a/pkg/cmd/git/get/get_test.go
+++ b/pkg/cmd/git/get/get_test.go
@@ -1,7 +1,6 @@
 package get_test
 
 import (
-	"io/ioutil"
 	"path/filepath"
 	"testing"
 
@@ -13,8 +12,7 @@ import (
 )
 
 func TestGitGetFromRepository(t *testing.T) {
-	tmpDir, err := ioutil.TempDir("", "")
-	require.NoError(t, err, "failed to create tmp dir")
+	tmpDir := t.TempDir()
 
 	_, o := get.NewCmdGitGet()
 
@@ -25,7 +23,7 @@ func TestGitGetFromRepository(t *testing.T) {
 	o.Path = "expected.txt"
 	o.FromRepository = "myorg/myrepo"
 
-	err = o.Run()
+	err := o.Run()
 	if err != nil {
 		require.NoError(t, err, "failed to run command")
 	}
@@ -37,8 +35,7 @@ func TestGitGetFromRepository(t *testing.T) {
 }
 
 func TestGitGetFromEnvironment(t *testing.T) {
-	tmpDir, err := ioutil.TempDir("", "")
-	require.NoError(t, err, "failed to create tmp dir")
+	tmpDir := t.TempDir()
 
 	ns := "jx"
 	devEnv := jxenv.CreateDefaultDevEnvironment(ns)
@@ -58,7 +55,7 @@ func TestGitGetFromEnvironment(t *testing.T) {
 	o.Env = "dev"
 	o.Namespace = ns
 
-	err = o.Run()
+	err := o.Run()
 	if err != nil {
 		require.NoError(t, err, "failed to run command")
 	}

--- a/pkg/cmd/git/merge/merge_test.go
+++ b/pkg/cmd/git/merge/merge_test.go
@@ -64,8 +64,7 @@ func TestGitMerge(t *testing.T) {
 		},
 	}
 
-	tmpDir, err := ioutil.TempDir("", "")
-	require.NoError(t, err, "failed to create tmp dir")
+	tmpDir := t.TempDir()
 
 	for _, tc := range testCases {
 		name := tc.name
@@ -166,8 +165,7 @@ func readRef(t *testing.T, repoDir, name string) string {
 func TestGitMergeFindCommits(t *testing.T) {
 	t.SkipNow()
 
-	tmpDir, err := ioutil.TempDir("", "")
-	require.NoError(t, err, "could not create temp dir")
+	tmpDir := t.TempDir()
 
 	_, o := merge.NewCmdGitMerge()
 	o.Dir = tmpDir
@@ -175,7 +173,7 @@ func TestGitMergeFindCommits(t *testing.T) {
 	o.BaseSHA = "0ec6b33a1bf37b3f06ecea6687763df4a528da9c"
 	o.ExcludeCommitComment = "^chore: regenerate"
 	o.PullNumber = "5"
-	err = o.Validate()
+	err := o.Validate()
 	require.NoError(t, err, "failed to validate")
 
 	g := o.GitClient

--- a/pkg/cmd/hash/hash_test.go
+++ b/pkg/cmd/hash/hash_test.go
@@ -1,7 +1,6 @@
 package hash_test
 
 import (
-	"io/ioutil"
 	"path/filepath"
 	"testing"
 
@@ -16,8 +15,7 @@ import (
 
 func TestUpdateAnnotatesInYamlFiles(t *testing.T) {
 	sourceDir := filepath.Join("test_data", "configs")
-	tmpDir, err := ioutil.TempDir("", "")
-	require.NoError(t, err, "could not create temp dir")
+	tmpDir := t.TempDir()
 
 	_, ho := hash.NewCmdHashAnnotate()
 	ho.SourceFiles = []string{
@@ -27,7 +25,7 @@ func TestUpdateAnnotatesInYamlFiles(t *testing.T) {
 	ho.Dir = tmpDir
 
 	deploymentsDir := filepath.Join("test_data", "deployments")
-	err = files.CopyDir(deploymentsDir, tmpDir, true)
+	err := files.CopyDir(deploymentsDir, tmpDir, true)
 	require.NoError(t, err, "failed to copy from %s to %s", deploymentsDir, tmpDir)
 
 	err = ho.Run()
@@ -50,8 +48,7 @@ func TestUpdateAnnotatesInYamlFiles(t *testing.T) {
 
 func TestUpdatePodSpecAnnotatesInYamlFiles(t *testing.T) {
 	sourceDir := filepath.Join("test_data", "configs")
-	tmpDir, err := ioutil.TempDir("", "")
-	require.NoError(t, err, "could not create temp dir")
+	tmpDir := t.TempDir()
 
 	_, ho := hash.NewCmdHashAnnotate()
 	ho.SourceFiles = []string{
@@ -62,7 +59,7 @@ func TestUpdatePodSpecAnnotatesInYamlFiles(t *testing.T) {
 	ho.PodSpec = true
 
 	deploymentsDir := filepath.Join("test_data", "deployments")
-	err = files.CopyDir(deploymentsDir, tmpDir, true)
+	err := files.CopyDir(deploymentsDir, tmpDir, true)
 	require.NoError(t, err, "failed to copy from %s to %s", deploymentsDir, tmpDir)
 
 	err = ho.Run()

--- a/pkg/cmd/helm/escape/escape_test.go
+++ b/pkg/cmd/helm/escape/escape_test.go
@@ -1,7 +1,6 @@
 package escape_test
 
 import (
-	"io/ioutil"
 	"path/filepath"
 	"testing"
 
@@ -15,10 +14,9 @@ func TestEscapeYAML(t *testing.T) {
 	srcDir := filepath.Join("test_data", "src")
 	require.DirExists(t, srcDir)
 
-	tmpDir, err := ioutil.TempDir("", "")
-	require.NoError(t, err, "could not create temp dir")
+	tmpDir := t.TempDir()
 
-	err = files.CopyDirOverwrite(srcDir, tmpDir)
+	err := files.CopyDirOverwrite(srcDir, tmpDir)
 	require.NoError(t, err, "failed to copy %s to %s", srcDir, tmpDir)
 
 	_, o := escape.NewCmdEscape()

--- a/pkg/cmd/helm/step_helm_template_test.go
+++ b/pkg/cmd/helm/step_helm_template_test.go
@@ -1,7 +1,6 @@
 package helm_test
 
 import (
-	"io/ioutil"
 	"path/filepath"
 	"testing"
 
@@ -22,8 +21,7 @@ func TestStepHelmTemplate(t *testing.T) {
 		return
 	}
 
-	tmpDir, err := ioutil.TempDir("", "")
-	require.NoError(t, err, "failed to create tmp dir")
+	tmpDir := t.TempDir()
 
 	name := "mychart"
 	o.HelmBinary = helmBin
@@ -35,7 +33,7 @@ func TestStepHelmTemplate(t *testing.T) {
 	runner := &fakerunner.FakeRunner{}
 	o.Gitter = cli.NewCLIClient("", runner.Run)
 
-	err = o.Run()
+	err := o.Run()
 	require.NoError(t, err, "failed to run the command")
 
 	if hasHelm {

--- a/pkg/cmd/helmfile/add/add_test.go
+++ b/pkg/cmd/helmfile/add/add_test.go
@@ -1,7 +1,6 @@
 package add_test
 
 import (
-	"io/ioutil"
 	"path/filepath"
 	"testing"
 
@@ -48,13 +47,12 @@ func TestStepHelmfileAdd(t *testing.T) {
 		},
 	}
 
-	tmpDir, err := ioutil.TempDir("", "")
-	require.NoError(t, err, "failed to create tmp dir")
+	tmpDir := t.TempDir()
 
 	srcDir := filepath.Join("test_data", "input")
 	require.DirExists(t, srcDir)
 
-	err = files.CopyDirOverwrite(srcDir, tmpDir)
+	err := files.CopyDirOverwrite(srcDir, tmpDir)
 	require.NoError(t, err, "failed to copy generated data at %s to %s", srcDir, tmpDir)
 
 	runner := &fakerunner.FakeRunner{

--- a/pkg/cmd/helmfile/deletecmd/delete_test.go
+++ b/pkg/cmd/helmfile/deletecmd/delete_test.go
@@ -1,7 +1,6 @@
 package deletecmd_test
 
 import (
-	"io/ioutil"
 	"path/filepath"
 	"testing"
 
@@ -49,15 +48,14 @@ func TestStepHelmfileDelete(t *testing.T) {
 		},
 	}
 
-	tmpDir, err := ioutil.TempDir("", "")
-	require.NoError(t, err, "failed to create tmp dir")
+	tmpDir := t.TempDir()
 
 	t.Logf("generating files to %s\n", tmpDir)
 
 	srcDir := filepath.Join("test_data")
 	require.DirExists(t, srcDir)
 
-	err = files.CopyDirOverwrite(srcDir, tmpDir)
+	err := files.CopyDirOverwrite(srcDir, tmpDir)
 	require.NoError(t, err, "failed to copy generated data at %s to %s", srcDir, tmpDir)
 
 	runner := &fakerunner.FakeRunner{

--- a/pkg/cmd/helmfile/move/move_test.go
+++ b/pkg/cmd/helmfile/move/move_test.go
@@ -1,7 +1,6 @@
 package move_test
 
 import (
-	"io/ioutil"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -51,8 +50,7 @@ func TestUpdateNamespaceInYamlFiles(t *testing.T) {
 
 	for _, test := range tests {
 
-		tmpDir, err := ioutil.TempDir("", "")
-		require.NoError(t, err, "could not create temp dir")
+		tmpDir := t.TempDir()
 
 		_, o := move.NewCmdHelmfileMove()
 
@@ -63,7 +61,7 @@ func TestUpdateNamespaceInYamlFiles(t *testing.T) {
 		o.DirIncludesReleaseName = test.hasReleaseName
 		o.AnnotateReleaseNames = true
 
-		err = o.Run()
+		err := o.Run()
 		require.NoError(t, err, "failed to run helmfile move")
 
 		for _, efn := range test.expectedFiles {

--- a/pkg/cmd/helmfile/report/markdown_test.go
+++ b/pkg/cmd/helmfile/report/markdown_test.go
@@ -19,13 +19,12 @@ var generateTestOutput = false
 func TestHemlfileMarkdownReport(t *testing.T) {
 	var charts []*releasereport.NamespaceReleases
 
-	tmpDir, err := ioutil.TempDir("", "")
-	require.NoError(t, err, "failed to create temp dir")
+	tmpDir := t.TempDir()
 
 	sourceFile := filepath.Join("test_data", "releases.yaml")
 	expectedPath := filepath.Join("test_data", "expected.README.md")
 
-	err = yamls.LoadFile(sourceFile, &charts)
+	err := yamls.LoadFile(sourceFile, &charts)
 	require.NoError(t, err, "failed to load file %s", sourceFile)
 	require.NotEmpty(t, charts, "no namespace charts found for %s", sourceFile)
 

--- a/pkg/cmd/helmfile/resolve/resolve_test.go
+++ b/pkg/cmd/helmfile/resolve/resolve_test.go
@@ -101,8 +101,7 @@ func TestStepHelmfileResolve(t *testing.T) {
 
 		_, o := resolve.NewCmdHelmfileResolve()
 
-		tmpDir, err := ioutil.TempDir("", "")
-		require.NoError(t, err, "failed to create tmp dir")
+		tmpDir := t.TempDir()
 
 		srcDir := filepath.Join("test_data", name)
 		require.DirExists(t, srcDir)

--- a/pkg/cmd/helmfile/structure/structure_test.go
+++ b/pkg/cmd/helmfile/structure/structure_test.go
@@ -1,7 +1,6 @@
 package structure_test
 
 import (
-	"io/ioutil"
 	"path/filepath"
 	"testing"
 
@@ -17,10 +16,9 @@ func TestHelmfileStructure(t *testing.T) {
 	srcDir := "test_data"
 	require.DirExists(t, srcDir)
 
-	tmpDir, err := ioutil.TempDir("", "")
-	require.NoError(t, err, "failed to create tmp dir")
+	tmpDir := t.TempDir()
 
-	err = files.CopyDirOverwrite(srcDir, tmpDir)
+	err := files.CopyDirOverwrite(srcDir, tmpDir)
 	require.NoError(t, err, "failed to copy test files at %s to %s", srcDir, tmpDir)
 
 	o := structure.Options{

--- a/pkg/cmd/helmfile/validate/validate_test.go
+++ b/pkg/cmd/helmfile/validate/validate_test.go
@@ -1,7 +1,6 @@
 package validate_test
 
 import (
-	"io/ioutil"
 	"path/filepath"
 	"testing"
 
@@ -50,13 +49,12 @@ func TestStepHelmfileStructure(t *testing.T) {
 
 	for _, tc := range testCases {
 
-		tmpDir, err := ioutil.TempDir("", "")
-		require.NoError(t, err, "failed to create tmp dir")
+		tmpDir := t.TempDir()
 
 		srcDir := filepath.Join("test_data", tc.testFolder)
 		require.DirExists(t, srcDir)
 
-		err = files.CopyDirOverwrite(srcDir, tmpDir)
+		err := files.CopyDirOverwrite(srcDir, tmpDir)
 		require.NoError(t, err, "failed to copy generated helmfiles at %s to %s", srcDir, tmpDir)
 
 		_, o := validate.NewCmdHelmfileValidate()

--- a/pkg/cmd/image/image_test.go
+++ b/pkg/cmd/image/image_test.go
@@ -1,7 +1,6 @@
 package image_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -21,10 +20,9 @@ func TestUpdateImages(t *testing.T) {
 	require.DirExists(t, inputDir)
 	require.DirExists(t, expectedDir)
 
-	tmpDir, err := ioutil.TempDir("", "")
-	require.NoError(t, err, "could not create temp dir")
+	tmpDir := t.TempDir()
 
-	err = files.CopyDirOverwrite(inputDir, tmpDir)
+	err := files.CopyDirOverwrite(inputDir, tmpDir)
 	require.NoError(t, err, "failed to copy %s to %s", inputDir, tmpDir)
 
 	o.SourceDir = filepath.Join(tmpDir, "src")

--- a/pkg/cmd/ingress/ingress_test.go
+++ b/pkg/cmd/ingress/ingress_test.go
@@ -34,10 +34,9 @@ func AssertUpdateIngress(t *testing.T, rootDir string) {
 	expectedData := filepath.Join(rootDir, "expected")
 	require.DirExists(t, expectedData)
 
-	tmpDir, err := ioutil.TempDir("", "")
-	require.NoError(t, err, "could not create temp dir")
+	tmpDir := t.TempDir()
 
-	err = files.CopyDir(sourceData, tmpDir, true)
+	err := files.CopyDir(sourceData, tmpDir, true)
 	require.NoError(t, err, "failed to copy from %s to %s", sourceData, tmpDir)
 
 	_, uo := ingress.NewCmdUpdateIngress()

--- a/pkg/cmd/jenkins/add/add_test.go
+++ b/pkg/cmd/jenkins/add/add_test.go
@@ -2,7 +2,6 @@ package add_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"path/filepath"
 	"testing"
 
@@ -20,14 +19,13 @@ import (
 )
 
 func TestJenkinsAdd(t *testing.T) {
-	tmpDir, err := ioutil.TempDir("", "")
-	require.NoError(t, err, "could not create temp dir")
+	tmpDir := t.TempDir()
 
 	srcDir := filepath.Join("test_data")
 
 	runner := &fakerunner.FakeRunner{}
 
-	err = files.CopyDirOverwrite(srcDir, tmpDir)
+	err := files.CopyDirOverwrite(srcDir, tmpDir)
 	require.NoError(t, err, "failed to copy from %s to %s", srcDir, tmpDir)
 
 	gitter := cli.NewCLIClient("", nil)

--- a/pkg/cmd/jenkins/jobs/jobs_test.go
+++ b/pkg/cmd/jenkins/jobs/jobs_test.go
@@ -1,7 +1,6 @@
 package jobs_test
 
 import (
-	"io/ioutil"
 	"path/filepath"
 	"testing"
 
@@ -20,12 +19,11 @@ import (
 const jenkinsName = "myjenkins"
 
 func TestJenkinsJobs(t *testing.T) {
-	tmpDir, err := ioutil.TempDir("", "")
-	require.NoError(t, err, "could not create temp dir")
+	tmpDir := t.TempDir()
 
 	srcDir := filepath.Join("test_data", "hasjobs")
 
-	err = files.CopyDirOverwrite(srcDir, tmpDir)
+	err := files.CopyDirOverwrite(srcDir, tmpDir)
 	require.NoError(t, err, "failed to copy from %s to %s", srcDir, tmpDir)
 
 	gitter := cli.NewCLIClient("", nil)
@@ -36,12 +34,11 @@ func TestJenkinsJobs(t *testing.T) {
 }
 
 func TestJenkinsJobsForExistingJenkins(t *testing.T) {
-	tmpDir, err := ioutil.TempDir("", "")
-	require.NoError(t, err, "could not create temp dir")
+	tmpDir := t.TempDir()
 
 	srcDir := filepath.Join("test_data", "hasjobs")
 
-	err = files.CopyDirOverwrite(srcDir, tmpDir)
+	err := files.CopyDirOverwrite(srcDir, tmpDir)
 	require.NoError(t, err, "failed to copy from %s to %s", srcDir, tmpDir)
 
 	gitter := cli.NewCLIClient("", nil)
@@ -101,13 +98,12 @@ func AssertGenerateJobs(t *testing.T, tmpDir, jenkinsName string) {
 }
 
 func TestNoJenkinsJobs(t *testing.T) {
-	tmpDir, err := ioutil.TempDir("", "")
-	require.NoError(t, err, "could not create temp dir")
+	tmpDir := t.TempDir()
 
 	_, o := jobs.NewCmdJenkinsJobs()
 	o.OutDir = tmpDir
 	o.Dir = filepath.Join("test_data", "nojobs")
 
-	err = o.Run()
+	err := o.Run()
 	require.NoError(t, err, "failed to run the command in dir %s", tmpDir)
 }

--- a/pkg/cmd/label/label_test.go
+++ b/pkg/cmd/label/label_test.go
@@ -25,8 +25,7 @@ func TestUpdateLabelsInYamlFiles(t *testing.T) {
 	}
 
 	for _, args := range argTests {
-		tmpDir, err := ioutil.TempDir("", "")
-		require.NoError(t, err, "could not create temp dir")
+		tmpDir := t.TempDir()
 
 		type testCase struct {
 			SourceFile   string

--- a/pkg/cmd/namespace/namespace_test.go
+++ b/pkg/cmd/namespace/namespace_test.go
@@ -22,8 +22,7 @@ func TestUpdateNamespaceInYamlFiles(t *testing.T) {
 	fileNames, err := ioutil.ReadDir(sourceData)
 	assert.NoError(t, err)
 
-	tmpDir, err := ioutil.TempDir("", "")
-	require.NoError(t, err, "could not create temp dir")
+	tmpDir := t.TempDir()
 
 	type testCase struct {
 		SourceFile   string
@@ -77,11 +76,10 @@ func TestNamespaceDirMode(t *testing.T) {
 	srcFile := filepath.Join("test_data", "dirmode")
 	require.DirExists(t, srcFile)
 
-	rootTmpDir, err := ioutil.TempDir("", "")
-	require.NoError(t, err, "could not create temp dir")
+	rootTmpDir := t.TempDir()
 
 	tmpDir := filepath.Join(rootTmpDir, "namespaces")
-	err = os.MkdirAll(tmpDir, files.DefaultDirWritePermissions)
+	err := os.MkdirAll(tmpDir, files.DefaultDirWritePermissions)
 	require.NoError(t, err, "failed to make namespaces dir")
 
 	err = files.CopyDirOverwrite(srcFile, tmpDir)

--- a/pkg/cmd/pr/variables/variables_test.go
+++ b/pkg/cmd/pr/variables/variables_test.go
@@ -2,11 +2,10 @@ package variables_test
 
 import (
 	"io/ioutil"
-	"strings"
-	"testing"
-
 	"os"
 	"path/filepath"
+	"strings"
+	"testing"
 
 	"github.com/jenkins-x-plugins/jx-gitops/pkg/cmd/pr/variables"
 	"github.com/jenkins-x-plugins/jx-gitops/pkg/fakerunners"
@@ -68,8 +67,7 @@ func TestPullRequestVariables(t *testing.T) {
 		},
 	}
 
-	tmpDir, err := ioutil.TempDir("", "")
-	require.NoError(t, err, "failed to create temp dir")
+	tmpDir := t.TempDir()
 
 	testDir := filepath.Join("test_data")
 	fs, err := ioutil.ReadDir(testDir)

--- a/pkg/cmd/rename/rename_test.go
+++ b/pkg/cmd/rename/rename_test.go
@@ -1,7 +1,6 @@
 package rename_test
 
 import (
-	"io/ioutil"
 	"path/filepath"
 	"testing"
 
@@ -15,10 +14,9 @@ func TestRenameYamlFiles(t *testing.T) {
 	srcFile := filepath.Join("test_data")
 	require.DirExists(t, srcFile)
 
-	tmpDir, err := ioutil.TempDir("", "")
-	require.NoError(t, err, "could not create temp dir")
+	tmpDir := t.TempDir()
 
-	err = files.CopyDirOverwrite(srcFile, tmpDir)
+	err := files.CopyDirOverwrite(srcFile, tmpDir)
 	require.NoError(t, err, "failed to copy %s to %s", srcFile, tmpDir)
 
 	_, o := rename.NewCmdRename()

--- a/pkg/cmd/repository/add/add_test.go
+++ b/pkg/cmd/repository/add/add_test.go
@@ -1,7 +1,6 @@
 package add_test
 
 import (
-	"io/ioutil"
 	"path/filepath"
 	"testing"
 
@@ -37,8 +36,7 @@ func TestRepositoryAdd(t *testing.T) {
 			provider: "https://github.com",
 		},
 	}
-	rootTmpDir, err := ioutil.TempDir("", "")
-	require.NoError(t, err, "could not create temp dir")
+	rootTmpDir := t.TempDir()
 
 	ns := "jx"
 	for _, tc := range testCases {
@@ -49,7 +47,7 @@ func TestRepositoryAdd(t *testing.T) {
 
 		t.Logf("running test %s in %s", name, tmpDir)
 
-		err = files.CopyDirOverwrite(sourceData, tmpDir)
+		err := files.CopyDirOverwrite(sourceData, tmpDir)
 		require.NoError(t, err, "failed to copy from %s to %s", sourceData, tmpDir)
 
 		sr := testjx.CreateSourceRepository(ns, tc.owner, tc.repo, tc.kind, tc.provider)

--- a/pkg/cmd/repository/create/create_test.go
+++ b/pkg/cmd/repository/create/create_test.go
@@ -19,12 +19,11 @@ var generateTestOutput = false
 func TestCreateRepositorySourceDir(t *testing.T) {
 	sourceData := filepath.Join("test_data", "input")
 
-	tmpDir, err := ioutil.TempDir("", "")
-	require.NoError(t, err, "could not create temp dir")
+	tmpDir := t.TempDir()
 
 	t.Logf("generating SourceRepository files in %s", tmpDir)
 
-	err = files.CopyDirOverwrite(sourceData, tmpDir)
+	err := files.CopyDirOverwrite(sourceData, tmpDir)
 	require.NoError(t, err, "failed to copy from %s to %s", sourceData, tmpDir)
 
 	_, o := create.NewCmdCreateRepository()

--- a/pkg/cmd/repository/deletecmd/delete_test.go
+++ b/pkg/cmd/repository/deletecmd/delete_test.go
@@ -32,10 +32,9 @@ func TestRepositoryDelete(t *testing.T) {
 			dir:   "simple",
 		},
 	}
-	rootTmpDir, err := ioutil.TempDir("", "")
-	require.NoError(t, err, "could not create temp dir")
+	rootTmpDir := t.TempDir()
 
-	err = files.CopyDirOverwrite("test_data", rootTmpDir)
+	err := files.CopyDirOverwrite("test_data", rootTmpDir)
 	require.NoError(t, err, "failed to copy from test_data to %s", rootTmpDir)
 
 	ns := "jx"

--- a/pkg/cmd/repository/export/export_test.go
+++ b/pkg/cmd/repository/export/export_test.go
@@ -1,7 +1,6 @@
 package export_test
 
 import (
-	"io/ioutil"
 	"path/filepath"
 	"testing"
 
@@ -17,8 +16,7 @@ import (
 )
 
 func TestExportRepositorySourceDir(t *testing.T) {
-	tmpDir, err := ioutil.TempDir("", "")
-	require.NoError(t, err, "failed to create tmp dir")
+	tmpDir := t.TempDir()
 
 	_, o := export.NewCmdExportConfig()
 	ns := "jx"
@@ -30,7 +28,7 @@ func TestExportRepositorySourceDir(t *testing.T) {
 	generatedFile := filepath.Join(tmpDir, v1alpha1.SourceConfigFileName)
 	o.ConfigFile = generatedFile
 
-	err = o.Run()
+	err := o.Run()
 	require.NoError(t, err, "failed to run the export")
 
 	t.Logf("generated export file %s", o.ConfigFile)

--- a/pkg/cmd/repository/resolve/resolve_test.go
+++ b/pkg/cmd/repository/resolve/resolve_test.go
@@ -19,8 +19,7 @@ func TestResolveRepositorySourceDir(t *testing.T) {
 	fileNames, err := ioutil.ReadDir(sourceData)
 	assert.NoError(t, err)
 
-	tmpDir, err := ioutil.TempDir("", "")
-	require.NoError(t, err, "could not create temp dir")
+	tmpDir := t.TempDir()
 
 	t.Logf("generating fileNames to %s\n", tmpDir)
 
@@ -80,11 +79,10 @@ func TestResolveRepositorySourceDir(t *testing.T) {
 func TestResolveRepositoryInRequirements(t *testing.T) {
 	srcFile := filepath.Join("test_data", "requirements", "jx-requirements.yml")
 
-	tmpDir, err := ioutil.TempDir("", "")
-	require.NoError(t, err, "could not create temp dir")
+	tmpDir := t.TempDir()
 
 	outFile := filepath.Join(tmpDir, "jx-requirements.yml")
-	err = files.CopyFile(srcFile, outFile)
+	err := files.CopyFile(srcFile, outFile)
 	require.NoError(t, err, "failed to copy %s to %s", srcFile, outFile)
 	require.FileExists(t, outFile)
 

--- a/pkg/cmd/requirement/edit/edit_test.go
+++ b/pkg/cmd/requirement/edit/edit_test.go
@@ -4,7 +4,6 @@ package edit_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -60,9 +59,7 @@ func TestCmdRequirementsEdit(t *testing.T) {
 		},
 	}
 
-	tmpDir, err := ioutil.TempDir("", "jx-cmd-req-")
-	require.NoError(t, err, "failed to create temp dir")
-	require.DirExists(t, tmpDir, "could not create temp dir for running tests")
+	tmpDir := t.TempDir()
 
 	for i, tt := range tests {
 		if tt.name == "" {
@@ -71,7 +68,7 @@ func TestCmdRequirementsEdit(t *testing.T) {
 		t.Logf("running test %s", tt.name)
 		dir := filepath.Join(tmpDir, tt.name)
 
-		err = os.MkdirAll(dir, files.DefaultDirWritePermissions)
+		err := os.MkdirAll(dir, files.DefaultDirWritePermissions)
 		require.NoError(t, err, "failed to create dir %s", dir)
 
 		localReqFile := filepath.Join(dir, jxcore.RequirementsConfigFileName)
@@ -84,7 +81,7 @@ func TestCmdRequirementsEdit(t *testing.T) {
 		cmd, _ := edit.NewCmdRequirementsEdit()
 		args := append(tt.args, "--dir", dir)
 
-		err := cmd.ParseFlags(args)
+		err = cmd.ParseFlags(args)
 		require.NoError(t, err, "failed to parse arguments %#v for test %", args, tt.name)
 
 		old := os.Args

--- a/pkg/cmd/requirement/merge/merge_test.go
+++ b/pkg/cmd/requirement/merge/merge_test.go
@@ -21,8 +21,7 @@ var generateTestOutput = false
 
 func TestRequirementsMergeFile(t *testing.T) {
 	// setup the disk
-	rootTmpDir, err := ioutil.TempDir("", "")
-	require.NoError(t, err, "could not create temp dir")
+	rootTmpDir := t.TempDir()
 
 	fileNames, err := ioutil.ReadDir("test_data")
 	assert.NoError(t, err)
@@ -67,13 +66,12 @@ func TestRequirementsMergeFile(t *testing.T) {
 
 func TestRequirementsMergeConfigMap(t *testing.T) {
 	// setup the disk
-	tmpDir, err := ioutil.TempDir("", "")
-	require.NoError(t, err, "could not create temp dir")
+	tmpDir := t.TempDir()
 
 	srcDir := filepath.Join("test_data", "sample")
 	require.DirExists(t, srcDir)
 
-	err = files.CopyDirOverwrite(srcDir, tmpDir)
+	err := files.CopyDirOverwrite(srcDir, tmpDir)
 	require.NoError(t, err, "failed to copy %s to %s", srcDir, tmpDir)
 
 	changesFile := filepath.Join("test_data", "sample", "changes.yml")
@@ -107,13 +105,12 @@ func TestRequirementsMergeConfigMap(t *testing.T) {
 
 func TestRequirementsMergeConfigMapDoesNotExist(t *testing.T) {
 	// setup the disk
-	tmpDir, err := ioutil.TempDir("", "")
-	require.NoError(t, err, "could not create temp dir")
+	tmpDir := t.TempDir()
 
 	srcDir := filepath.Join("test_data", "sample")
 	require.DirExists(t, srcDir)
 
-	err = files.CopyDirOverwrite(srcDir, tmpDir)
+	err := files.CopyDirOverwrite(srcDir, tmpDir)
 	require.NoError(t, err, "failed to copy %s to %s", srcDir, tmpDir)
 
 	// now lets run the command

--- a/pkg/cmd/requirement/publish/publish_test.go
+++ b/pkg/cmd/requirement/publish/publish_test.go
@@ -1,7 +1,6 @@
 package publish_test
 
 import (
-	"io/ioutil"
 	"path/filepath"
 	"testing"
 
@@ -13,10 +12,9 @@ import (
 )
 
 func TestRequirementsPublish(t *testing.T) {
-	tmpDir, err := ioutil.TempDir("", "")
-	require.NoError(t, err, "could not create temp dir")
+	tmpDir := t.TempDir()
 
-	err = files.CopyDirOverwrite("test_data", tmpDir)
+	err := files.CopyDirOverwrite("test_data", tmpDir)
 	require.NoError(t, err, "failed to copy %s to %s", "test_data", tmpDir)
 
 	_, o := publish.NewCmdRequirementsPublish()

--- a/pkg/cmd/requirement/resolve/resolve_test.go
+++ b/pkg/cmd/requirement/resolve/resolve_test.go
@@ -1,7 +1,6 @@
 package resolve_test
 
 import (
-	"io/ioutil"
 	"path/filepath"
 	"testing"
 
@@ -65,13 +64,12 @@ func TestRequirementsResolveGKE(t *testing.T) {
 	}
 
 	// setup the disk
-	tmpDir, err := ioutil.TempDir("", "")
-	require.NoError(t, err, "could not create temp dir")
+	tmpDir := t.TempDir()
 
 	srcFile := filepath.Join("test_data", "gke")
 	require.DirExists(t, srcFile)
 
-	err = files.CopyDirOverwrite(srcFile, tmpDir)
+	err := files.CopyDirOverwrite(srcFile, tmpDir)
 	require.NoError(t, err, "failed to copy %s to %s", srcFile, tmpDir)
 
 	// now lets run the command
@@ -101,13 +99,12 @@ func TestRequirementsResolveGKE(t *testing.T) {
 
 func TestRequirementsResolvePipelineUser(t *testing.T) {
 	// setup the disk
-	tmpDir, err := ioutil.TempDir("", "")
-	require.NoError(t, err, "could not create temp dir")
+	tmpDir := t.TempDir()
 
 	srcFile := filepath.Join("test_data", "eks")
 	require.DirExists(t, srcFile)
 
-	err = files.CopyDirOverwrite(srcFile, tmpDir)
+	err := files.CopyDirOverwrite(srcFile, tmpDir)
 	require.NoError(t, err, "failed to copy %s to %s", srcFile, tmpDir)
 
 	// now lets run the command

--- a/pkg/cmd/sa/secret/secret_test.go
+++ b/pkg/cmd/sa/secret/secret_test.go
@@ -1,7 +1,6 @@
 package secret_test
 
 import (
-	"io/ioutil"
 	"path/filepath"
 	"testing"
 
@@ -14,12 +13,11 @@ import (
 )
 
 func TestServiceAccountSecret(t *testing.T) {
-	tmpDir, err := ioutil.TempDir("", "")
-	require.NoError(t, err, "could not create temp dir")
+	tmpDir := t.TempDir()
 
 	sourceData := filepath.Join("test_data")
 
-	err = files.CopyDirOverwrite(sourceData, tmpDir)
+	err := files.CopyDirOverwrite(sourceData, tmpDir)
 	require.NoError(t, err, "failed to copy generated crds at %s to %s", sourceData, tmpDir)
 
 	_, o := secret.NewCmdServiceAccountSecrets()

--- a/pkg/cmd/scheduler/scheduler_test.go
+++ b/pkg/cmd/scheduler/scheduler_test.go
@@ -1,7 +1,6 @@
 package scheduler_test
 
 import (
-	"io/ioutil"
 	"path/filepath"
 	"testing"
 
@@ -21,15 +20,14 @@ func TestScheduler(t *testing.T) {
 	sourceDir := filepath.Join("test_data")
 	require.DirExists(t, sourceDir)
 
-	tmpDir, err := ioutil.TempDir("", "")
-	require.NoError(t, err, "could not create temp dir")
+	tmpDir := t.TempDir()
 
 	_, so := scheduler.NewCmdScheduler()
 
 	so.OutDir = tmpDir
 	so.Dir = sourceDir
 
-	err = so.Run()
+	err := so.Run()
 	require.NoError(t, err, "failed to run scheduler command")
 
 	configFile := filepath.Join(tmpDir, scheduler.ConfigMapConfigFileName)

--- a/pkg/cmd/split/split_test.go
+++ b/pkg/cmd/split/split_test.go
@@ -2,7 +2,6 @@ package split_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"path/filepath"
 	"testing"
 
@@ -17,10 +16,9 @@ func TestSplitYamlFiles(t *testing.T) {
 	srcFile := filepath.Join("test_data")
 	require.DirExists(t, srcFile)
 
-	tmpDir, err := ioutil.TempDir("", "")
-	require.NoError(t, err, "could not create temp dir")
+	tmpDir := t.TempDir()
 
-	err = files.CopyDirOverwrite(srcFile, tmpDir)
+	err := files.CopyDirOverwrite(srcFile, tmpDir)
 	require.NoError(t, err, "failed to copy %s to %s", srcFile, tmpDir)
 
 	o := &split.Options{
@@ -52,10 +50,9 @@ func TestSplitHelmTemplateYamlFiles(t *testing.T) {
 	srcFile := filepath.Join("test_data", "helm")
 	require.DirExists(t, srcFile)
 
-	tmpDir, err := ioutil.TempDir("", "")
-	require.NoError(t, err, "could not create temp dir")
+	tmpDir := t.TempDir()
 
-	err = files.CopyDirOverwrite(srcFile, tmpDir)
+	err := files.CopyDirOverwrite(srcFile, tmpDir)
 	require.NoError(t, err, "failed to copy %s to %s", srcFile, tmpDir)
 
 	o := &split.Options{

--- a/pkg/cmd/variables/variables_test.go
+++ b/pkg/cmd/variables/variables_test.go
@@ -34,8 +34,7 @@ func TestCmdVariables(t *testing.T) {
 		return
 	}
 
-	tmpDir, err := ioutil.TempDir("", "")
-	require.NoError(t, err, "failed to create temp dir")
+	tmpDir := t.TempDir()
 
 	testDir := filepath.Join("test_data", "tests")
 	fs, err := ioutil.ReadDir(testDir)

--- a/pkg/cmd/yset/yset_test.go
+++ b/pkg/cmd/yset/yset_test.go
@@ -37,8 +37,7 @@ func TestYSet(t *testing.T) {
 		},
 	}
 
-	tmpDir, err := ioutil.TempDir("", "")
-	require.NoError(t, err, "could not create temp dir")
+	tmpDir := t.TempDir()
 
 	for _, tc := range testCases {
 		name := tc.dir
@@ -49,7 +48,7 @@ func TestYSet(t *testing.T) {
 		require.FileExists(t, expectedFile)
 
 		outFile := filepath.Join(tmpDir, name+".yaml")
-		err = files.CopyFile(srcFile, outFile)
+		err := files.CopyFile(srcFile, outFile)
 		require.NoError(t, err, "failed to copy %s to %s", srcFile, outFile)
 
 		_, o := yset.NewCmdYSet()

--- a/pkg/tfupgrade/tfupgrade_test.go
+++ b/pkg/tfupgrade/tfupgrade_test.go
@@ -14,8 +14,7 @@ import (
 )
 
 func TestTerraformUpgrade(t *testing.T) {
-	tmpDir, err := ioutil.TempDir("", "")
-	require.NoError(t, err, "could not create temp dir")
+	tmpDir := t.TempDir()
 
 	fileNames, err := ioutil.ReadDir("test_data")
 	assert.NoError(t, err)

--- a/pkg/variablefinders/requirements_test.go
+++ b/pkg/variablefinders/requirements_test.go
@@ -25,8 +25,7 @@ func TestFindRequirements(t *testing.T) {
 	ns := "jx"
 	devGitURL := "https://github.com/myorg/myrepo.git"
 
-	tmpDir, err := ioutil.TempDir("", "")
-	require.NoError(t, err, "could not create temp dir")
+	tmpDir := t.TempDir()
 
 	devEnv := jxenv.CreateDefaultDevEnvironment(ns)
 	devEnv.Namespace = ns


### PR DESCRIPTION
A testing cleanup. This PR replaces `ioutil.TempDir` with `t.TempDir` in tests.

We can use the `T.TempDir` function from the `testing` package to create temporary directory. The directory created by `T.TempDir` is automatically removed when the test and all its subtests complete.

Reference: https://pkg.go.dev/testing#T.TempDir