### PR TITLE
WIP - Work on adding darwin arm64 support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -126,6 +126,10 @@ darwin: ## Build for OSX
 	CGO_ENABLED=$(CGO_ENABLED) GOOS=darwin GOARCH=amd64 $(GO) $(BUILD_TARGET) $(BUILDFLAGS) -o build/darwin/$(NAME) $(MAIN_SRC_FILE)
 	chmod +x build/darwin/$(NAME)
 
+darwin-arm: ## Build for OSX
+	CGO_ENABLED=$(CGO_ENABLED) GOOS=darwin GOARCH=arm64 $(GO) $(BUILD_TARGET) $(BUILDFLAGS) -o build/darwin-arm/$(NAME) $(MAIN_SRC_FILE)
+	chmod +x build/darwin-arm/$(NAME)
+
 .PHONY: release
 release: clean linux test
 

--- a/pkg/plugins/versions.go
+++ b/pkg/plugins/versions.go
@@ -22,13 +22,13 @@ const (
 	KustomizePluginName = "kustomize"
 
 	// HelmVersion the default version of helm to use
-	HelmVersion = "3.7.2"
+	HelmVersion = "3.8.2"
 
 	// HelmfileVersion the default version of helmfile to use
 	HelmfileVersion = "0.143.0"
 
 	// KptVersion the default version of kpt to use
-	KptVersion = "0.37.0"
+	KptVersion = "v1.0.0-beta.14"
 
 	// KubectlVersion the default version of kpt to use
 	KubectlVersion = "1.21.0"


### PR DESCRIPTION
This PR adds a make target to build darwin arm64 support and bumps
the kpt version to a current beta.  The current kpt version does
not compile on darwin arm64, so in order to have m1 support,
kpt needs an upgrade.  This also causes an upgrade of all of the
'Kpt' files, as the schema has changed.  I will push a pr to the
eks vault repo as an example.

TODO - the merge type has changed, so we need to decide what
default merge type we want and we need to change that in this
PR as well.

A workaround to not bump the version is move the kpt binary path option to the jx-gitops itself,
for instance `jx-gitops update` does not take the path to the kpt binary. You can still just the plugin
and kpt using the different ENV variables.

So I am happy to take out the version update, and put in another PR with it. But we should have
the path to the kpt binary in every time it is used.

This PR will also depend on https://github.com/jenkins-x/jx-helpers/pull/369