### PR TITLE
fix: show both release and chart names in report

### DIFF
--- a/pkg/cmd/helmfile/report/markdown.go
+++ b/pkg/cmd/helmfile/report/markdown.go
@@ -22,6 +22,7 @@ func ToMarkdown(charts []*releasereport.NamespaceReleases) (string, error) {
   <thead>
     <tr>
       <th scope="col">Release</th>
+      <th scope="col">Chart</th>
       <th scope="col">Version</th>
       <th scope="col">Open</th>
       <th scope="col">Source</th>
@@ -49,7 +50,7 @@ func WriteNamespaceCharts(w io.StringWriter, ns *releasereport.NamespaceReleases
 	}
 
 	_, err := w.WriteString(fmt.Sprintf(`    <tr>
-		      <td colspan='4'><h3>%s</h3></td>
+		      <td colspan='5'><h3>%s</h3></td>
 		    </tr>
 	`, ns.Namespace))
 	if err != nil {
@@ -73,12 +74,13 @@ func WriteChart(w io.StringWriter, ch *releasereport.ReleaseInfo) {
 	}
 
 	_, err := w.WriteString(fmt.Sprintf(`    <tr>
+	      <td>%s</td>
 	      <td><a href='%s' title='%s'> <img src='%s' width='24px' height='24px'> %s </a></td>
 	      <td>%s</td>
 	      <td>%s</td>
 	      <td>%s</td>
 	    </tr>
-`, ch.Home, description, ch.Icon, ch.Name, ch.Version, viewLink, sourceLink))
+`, ch.ReleaseName, ch.Home, description, ch.Icon, ch.Name, ch.Version, viewLink, sourceLink))
 	if err != nil {
 		log.Logger().Warn(err)
 	}

--- a/pkg/cmd/helmfile/report/report.go
+++ b/pkg/cmd/helmfile/report/report.go
@@ -303,6 +303,7 @@ func (o *Options) createReleaseInfo(helmState *state.HelmState, ns string, rel *
 		}
 	}
 
+	answer.ReleaseName = rel.Name
 	answer.LogsURL = getLogURL(&o.Requirements.Spec, ns, answer.Name)
 	return answer, nil
 }

--- a/pkg/cmd/helmfile/report/test_data/expected.README.md
+++ b/pkg/cmd/helmfile/report/test_data/expected.README.md
@@ -5,6 +5,7 @@
   <thead>
     <tr>
       <th scope="col">Release</th>
+      <th scope="col">Chart</th>
       <th scope="col">Version</th>
       <th scope="col">Open</th>
       <th scope="col">Source</th>
@@ -12,63 +13,72 @@
   </thead>
   <tbody>
     <tr>
-		      <td colspan='4'><h3>cert-manager</h3></td>
+		      <td colspan='5'><h3>cert-manager</h3></td>
 		    </tr>
 	    <tr>
+	      <td>cert-manager</td>
 	      <td><a href='https://github.com/jetstack/cert-manager' title='A Helm chart for cert-manager'> <img src='https://raw.githubusercontent.com/jetstack/cert-manager/master/logo/logo.png' width='24px' height='24px'> cert-manager </a></td>
 	      <td>1.1.0</td>
 	      <td></td>
 	      <td><a href='https://github.com/jetstack/cert-manager'>source</a></td>
 	    </tr>
     <tr>
-		      <td colspan='4'><h3>jx-staging</h3></td>
+		      <td colspan='5'><h3>jx-staging</h3></td>
 		    </tr>
 	    <tr>
+	      <td>nodey554</td>
 	      <td><a href='' title='A Helm chart for Kubernetes'> <img src='https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png' width='24px' height='24px'> nodey554 </a></td>
 	      <td>1.0.20</td>
 	      <td></td>
 	      <td></td>
 	    </tr>
     <tr>
+	      <td>nodey545</td>
 	      <td><a href='' title='A Helm chart for Kubernetes'> <img src='https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png' width='24px' height='24px'> nodey545 </a></td>
 	      <td>3.0.46</td>
 	      <td><a href='http://nodey545-jx-staging.34.105.246.143.xip.io'>view</a></td>
 	      <td></td>
 	    </tr>
     <tr>
-		      <td colspan='4'><h3>jx</h3></td>
+		      <td colspan='5'><h3>jx</h3></td>
 		    </tr>
 	    <tr>
+	      <td>external-dns</td>
 	      <td><a href='https://github.com/kubernetes-sigs/external-dns' title='ExternalDNS is a Kubernetes addon that configures public DNS servers with information about exposed Kubernetes services to make them discoverable.'> <img src='https://bitnami.com/assets/stacks/external-dns/img/external-dns-stack-110x117.png' width='24px' height='24px'> external-dns </a></td>
 	      <td>3.2.0</td>
 	      <td></td>
 	      <td><a href='https://github.com/kubernetes-sigs/external-dns'>source</a></td>
 	    </tr>
     <tr>
+	      <td>acme</td>
 	      <td><a href='' title='Acme'> <img src='https://avatars2.githubusercontent.com/u/35583233?s=200&v=4' width='24px' height='24px'> acme </a></td>
 	      <td>0.0.18</td>
 	      <td></td>
 	      <td></td>
 	    </tr>
     <tr>
+	      <td>jxboot-helmfile-resources</td>
 	      <td><a href='https://github.com/jenkins-x-charts/jxboot-helmfile-resources' title='A Helm chart for the resources for JX Boot'> <img src='https://raw.githubusercontent.com/jenkins-x/jenkins-x-website/master/images/logo/jenkinsx-icon-color.svg' width='24px' height='24px'> jxboot-helmfile-resources </a></td>
 	      <td>1.0.23</td>
 	      <td></td>
 	      <td><a href='https://github.com/jenkins-x-charts/jxboot-helmfile-resources'>source</a></td>
 	    </tr>
     <tr>
+	      <td>jenkins-x-crds</td>
 	      <td><a href='' title='Custom Resource Definitions for Jenkins X'> <img src='https://raw.githubusercontent.com/jenkins-x/jenkins-x-platform/d273e09/images/go.png' width='24px' height='24px'> jenkins-x-crds </a></td>
 	      <td>3.0.5</td>
 	      <td></td>
 	      <td></td>
 	    </tr>
     <tr>
+	      <td>jx-pipelines-visualizer</td>
 	      <td><a href='https://github.com/jenkins-x/jx-pipelines-visualizer' title='Web UI for Jenkins X, with a clear goal - visualize the pipelines - and their logs.'> <img src='' width='24px' height='24px'> jx-pipelines-visualizer </a></td>
 	      <td>0.0.61</td>
 	      <td><a href='http://dashboard-jx.34.105.246.143.xip.io'>view</a></td>
 	      <td><a href='https://github.com/jenkins-x/jx-pipelines-visualizer'>source</a></td>
 	    </tr>
     <tr>
+	      <td>jx-preview</td>
 	      <td><a href='https://github.com/jenkins-x/jx-preview' title='This chart installs the jx-preview CRD and garbagecollection job
 '> <img src='https://raw.githubusercontent.com/jenkins-x/jenkins-x-website/master/images/logo/jenkinsx-icon-color.svg' width='24px' height='24px'> jx-preview </a></td>
 	      <td>0.0.138</td>
@@ -76,6 +86,7 @@
 	      <td><a href='https://github.com/jenkins-x/jx-preview'>source</a></td>
 	    </tr>
     <tr>
+	      <td>lighthouse</td>
 	      <td><a href='https://github.com/jenkins-x/lighthouse' title='This chart bootstraps installation of [Lighthouse](https://github.com/jenkins-x/lighthouse).
 '> <img src='https://raw.githubusercontent.com/jenkins-x/jenkins-x-website/master/images/logo/jenkinsx-icon-color.svg' width='24px' height='24px'> lighthouse </a></td>
 	      <td>0.0.903</td>
@@ -83,66 +94,75 @@
 	      <td><a href='https://github.com/jenkins-x/lighthouse'>source</a></td>
 	    </tr>
     <tr>
+	      <td>nexus</td>
 	      <td><a href='https://github.com/jenkins-x-charts/nexus' title='A Helm chart for Kubernetes'> <img src='https://raw.githubusercontent.com/jenkins-x/jenkins-x-platform/master/jenkins-x-platform/images/nexus.png' width='24px' height='24px'> nexus </a></td>
 	      <td>0.1.35</td>
 	      <td></td>
 	      <td><a href='https://github.com/jenkins-x-charts/nexus'>source</a></td>
 	    </tr>
     <tr>
+	      <td>chartmuseum</td>
 	      <td><a href='https://github.com/helm/chartmuseum' title='Host your own Helm Chart Repository'> <img src='https://raw.githubusercontent.com/helm/chartmuseum/master/logo2.png' width='24px' height='24px'> chartmuseum </a></td>
 	      <td>2.4.1</td>
 	      <td></td>
 	      <td><a href='https://github.com/helm/chartmuseum'>source</a></td>
 	    </tr>
     <tr>
+	      <td>jx-build-controller</td>
 	      <td><a href='https://jenkins-x.io/' title='Jenkins X next gen cloud CI / CD platform for Kubernetes'> <img src='https://jenkins-x.github.io/jenkins-x-website/img/profile.png' width='24px' height='24px'> jx-build-controller </a></td>
 	      <td>0.0.20</td>
 	      <td></td>
 	      <td><a href='https://jenkins-x.io/'>source</a></td>
 	    </tr>
     <tr>
-		      <td colspan='4'><h3>myjenkinsa</h3></td>
+		      <td colspan='5'><h3>myjenkinsa</h3></td>
 		    </tr>
 	    <tr>
+	      <td>jenkins</td>
 	      <td><a href='https://jenkins.io/' title='Jenkins - Build great things at any scale! The leading open source automation server, Jenkins provides hundreds of plugins to support building, deploying and automating any project.'> <img src='https://wiki.jenkins-ci.org/download/attachments/2916393/logo.png' width='24px' height='24px'> jenkins </a></td>
 	      <td></td>
 	      <td><a href='http://jenkins-myjenkinsa.34.105.246.143.xip.io'>view</a></td>
 	      <td><a href='https://jenkins.io/'>source</a></td>
 	    </tr>
     <tr>
+	      <td>jenkins-resources</td>
 	      <td><a href='' title=''> <img src='' width='24px' height='24px'> jenkins-resources </a></td>
 	      <td></td>
 	      <td></td>
 	      <td></td>
 	    </tr>
     <tr>
-		      <td colspan='4'><h3>nginx</h3></td>
+		      <td colspan='5'><h3>nginx</h3></td>
 		    </tr>
 	    <tr>
+	      <td>ingress-nginx</td>
 	      <td><a href='https://github.com/kubernetes/ingress-nginx' title='Ingress controller for Kubernetes using NGINX as a reverse proxy and load balancer'> <img src='https://upload.wikimedia.org/wikipedia/commons/thumb/c/c5/Nginx_logo.svg/500px-Nginx_logo.svg.png' width='24px' height='24px'> ingress-nginx </a></td>
 	      <td>3.12.0</td>
 	      <td></td>
 	      <td><a href='https://github.com/kubernetes/ingress-nginx'>source</a></td>
 	    </tr>
     <tr>
-		      <td colspan='4'><h3>secret-infra</h3></td>
+		      <td colspan='5'><h3>secret-infra</h3></td>
 		    </tr>
 	    <tr>
+	      <td>kubernetes-external-secrets</td>
 	      <td><a href='https://github.com/godaddy/kubernetes-external-secrets' title='Kubernetes External Secrets CustomResourceDefinition'> <img src='' width='24px' height='24px'> kubernetes-external-secrets </a></td>
 	      <td>6.0.0</td>
 	      <td></td>
 	      <td><a href='https://github.com/godaddy/kubernetes-external-secrets'>source</a></td>
 	    </tr>
     <tr>
+	      <td>pusher-wave</td>
 	      <td><a href='https://github.com/pusher/wave' title='wave chart that runs on kubernetes'> <img src='' width='24px' height='24px'> pusher-wave </a></td>
 	      <td>0.4.12</td>
 	      <td></td>
 	      <td><a href='https://github.com/pusher/wave'>source</a></td>
 	    </tr>
     <tr>
-		      <td colspan='4'><h3>tekton-pipelines</h3></td>
+		      <td colspan='5'><h3>tekton-pipelines</h3></td>
 		    </tr>
 	    <tr>
+	      <td>tekton-pipeline</td>
 	      <td><a href='https://github.com/cdfoundation/tekton-helm-chart' title='A Helm chart for Tekton Pipelines'> <img src='https://avatars2.githubusercontent.com/u/47602533' width='24px' height='24px'> tekton-pipeline </a></td>
 	      <td>0.19.0</td>
 	      <td></td>

--- a/pkg/cmd/helmfile/report/test_data/releases.yaml
+++ b/pkg/cmd/helmfile/report/test_data/releases.yaml
@@ -15,6 +15,7 @@
     - email: james@jetstack.io
       name: munnerz
     name: cert-manager
+    releaseName: cert-manager
     repositoryName: jetstack
     repositoryUrl: https://charts.jetstack.io
     sources:
@@ -29,6 +30,7 @@
     description: A Helm chart for Kubernetes
     icon: https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png
     name: nodey554
+    releaseName: nodey554
     repositoryName: dev
     repositoryUrl: http://chartmuseum-jx.34.105.246.143.xip.io/
     resourcePath: config-root/namespaces/jx-staging/nodey554
@@ -41,6 +43,7 @@
     - name: nodey545
       url: http://nodey545-jx-staging.34.105.246.143.xip.io
     name: nodey545
+    releaseName: nodey545
     repositoryName: dev
     repositoryUrl: http://chartmuseum-jx.34.105.246.143.xip.io/
     resourcePath: config-root/namespaces/jx-staging/nodey545
@@ -61,6 +64,7 @@
     - email: containers@bitnami.com
       name: Bitnami
     name: external-dns
+    releaseName: external-dns
     repositoryName: bitnami
     repositoryUrl: https://charts.bitnami.com/bitnami
     sources:
@@ -71,6 +75,7 @@
     description: Acme
     icon: https://avatars2.githubusercontent.com/u/35583233?s=200&v=4
     name: acme
+    releaseName: acme
     repositoryName: jx3
     repositoryUrl: https://storage.googleapis.com/jenkinsxio/charts
     version: 0.0.18
@@ -95,6 +100,7 @@
     - name: nexus
       url: http://nexus-jx.34.105.246.143.xip.io/
     name: jxboot-helmfile-resources
+    releaseName: jxboot-helmfile-resources
     repositoryName: jenkins-x
     repositoryUrl: https://storage.googleapis.com/chartmuseum.jenkins-x.io
     resourcePath: config-root/namespaces/jx/jxboot-helmfile-resources
@@ -104,6 +110,7 @@
     description: Custom Resource Definitions for Jenkins X
     icon: https://raw.githubusercontent.com/jenkins-x/jenkins-x-platform/d273e09/images/go.png
     name: jenkins-x-crds
+    releaseName: jenkins-x-crds
     repositoryName: jx3
     repositoryUrl: https://storage.googleapis.com/jenkinsxio/charts
     resourcePath: config-root/namespaces/jx/jenkins-x-crds
@@ -117,6 +124,7 @@
     - name: jx-pipelines-visualizer
       url: http://dashboard-jx.34.105.246.143.xip.io
     name: jx-pipelines-visualizer
+    releaseName: jx-pipelines-visualizer
     repositoryName: jx3
     repositoryUrl: https://storage.googleapis.com/jenkinsxio/charts
     resourcePath: config-root/namespaces/jx/jx-pipelines-visualizer
@@ -129,6 +137,7 @@
     home: https://github.com/jenkins-x/jx-preview
     icon: https://raw.githubusercontent.com/jenkins-x/jenkins-x-website/master/images/logo/jenkinsx-icon-color.svg
     name: jx-preview
+    releaseName: jx-preview
     repositoryName: jx3
     repositoryUrl: https://storage.googleapis.com/jenkinsxio/charts
     resourcePath: config-root/namespaces/jx/jx-preview
@@ -140,6 +149,7 @@
     home: https://github.com/jenkins-x/lighthouse
     icon: https://raw.githubusercontent.com/jenkins-x/jenkins-x-website/master/images/logo/jenkinsx-icon-color.svg
     name: lighthouse
+    releaseName: lighthouse
     repositoryName: jenkins-x
     repositoryUrl: https://storage.googleapis.com/chartmuseum.jenkins-x.io
     resourcePath: config-root/namespaces/jx/lighthouse
@@ -149,6 +159,7 @@
     home: https://github.com/jenkins-x-charts/nexus
     icon: https://raw.githubusercontent.com/jenkins-x/jenkins-x-platform/master/jenkins-x-platform/images/nexus.png
     name: nexus
+    releaseName: nexus
     repositoryName: jenkins-x
     repositoryUrl: https://storage.googleapis.com/chartmuseum.jenkins-x.io
     resourcePath: config-root/namespaces/jx/nexus
@@ -170,6 +181,7 @@
     - email: chartmuseum@gmail.com
       name: chartmuseum
     name: chartmuseum
+    releaseName: chartmuseum
     repositoryName: stable
     repositoryUrl: https://charts.helm.sh/stable
     resourcePath: config-root/namespaces/jx/chartmuseum
@@ -183,6 +195,7 @@
     - email: jenkins-x@googlegroups.com
       name: Jenkins X Team
     name: jx-build-controller
+    releaseName: jx-build-controller
     repositoryName: jx3
     repositoryUrl: https://storage.googleapis.com/jenkinsxio/charts
     resourcePath: config-root/namespaces/jx/jx-build-controller
@@ -219,6 +232,7 @@
     - email: timjacomb1@gmail.com
       name: timja
     name: jenkins
+    releaseName: jenkins
     repositoryName: jenkinsci
     repositoryUrl: https://charts.jenkins.io
     resourcePath: config-root/namespaces/myjenkinsa/jenkins
@@ -228,6 +242,7 @@
     - https://github.com/maorfr/kube-tasks
     - https://github.com/jenkinsci/configuration-as-code-plugin
   - name: jenkins-resources
+    releaseName: jenkins-resources
     repositoryName: jx3
     repositoryUrl: https://charts.jenkins.io
     resourcePath: config-root/namespaces/myjenkinsa/jenkins-resources
@@ -249,6 +264,7 @@
     maintainers:
     - name: ChiefAlexander
     name: ingress-nginx
+    releaseName: ingress-nginx
     repositoryName: ingress-nginx
     repositoryUrl: https://kubernetes.github.io/ingress-nginx
     resourcePath: config-root/namespaces/nginx/ingress-nginx
@@ -272,6 +288,7 @@
     - email: klu6@godaddy.com
       name: keweilu
     name: kubernetes-external-secrets
+    releaseName: kubernetes-external-secrets
     repositoryName: external-secrets
     repositoryUrl: https://external-secrets.github.io/kubernetes-external-secrets
     resourcePath: config-root/namespaces/secret-infra/kubernetes-external-secrets
@@ -286,6 +303,7 @@
     - wave
     - kubernetes
     name: pusher-wave
+    releaseName: pusher-wave
     repositoryName: jx3
     repositoryUrl: https://storage.googleapis.com/jenkinsxio/charts
     resourcePath: config-root/namespaces/secret-infra/pusher-wave
@@ -301,6 +319,7 @@
     home: https://github.com/cdfoundation/tekton-helm-chart
     icon: https://avatars2.githubusercontent.com/u/47602533
     name: tekton-pipeline
+    releaseName: tekton-pipeline
     repositoryName: cdf
     repositoryUrl: https://cdfoundation.github.io/tekton-helm-chart
     resourcePath: config-root/namespaces/tekton-pipelines/tekton-pipeline

--- a/pkg/releasereport/types.go
+++ b/pkg/releasereport/types.go
@@ -18,6 +18,9 @@ type NamespaceReleases struct {
 type ReleaseInfo struct {
 	chart.Metadata
 
+	// ReleaseName is the name of the helm release
+	ReleaseName string `json:"releaseName,omitempty"`
+
 	// FirstDeployed is when the chart version was first deployed.
 	FirstDeployed *metav1.Time `json:"firstDeployed,omitempty"`
 	// LastDeployed is when the release was last deployed.


### PR DESCRIPTION
This covers the use case where a chart is deployed multiple times in the same namespace with different release names
(see https://kubernetes.slack.com/archives/C9LTHT2BB/p1619666560425000 for an examlple