### PR TITLE
fix: Correct namespace for resources

### DIFF
--- a/pkg/cmd/helmfile/move/move.go
+++ b/pkg/cmd/helmfile/move/move.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/jenkins-x-plugins/jx-gitops/pkg/helmhelpers"
 	"github.com/jenkins-x-plugins/jx-gitops/pkg/rootcmd"
-	"github.com/jenkins-x/jx-api/v4/pkg/client/clientset/versioned"
 	"github.com/jenkins-x/jx-helpers/v3/pkg/cobras/helper"
 	"github.com/jenkins-x/jx-helpers/v3/pkg/cobras/templates"
 	"github.com/jenkins-x/jx-helpers/v3/pkg/files"
@@ -223,9 +222,7 @@ func (o *Options) lazyCreateNamespaceResource(ns string) error {
 }
 
 func (o *Options) moveFilesToClusterOrNamespacesFolder(dir, ns, releaseName, chartName string) error {
-	o.ClusterWide = make(map[string]bool)
-	JXClient, err := jxclient.LazyCreateJXClient(nil)
-	err = filepath.Walk(dir, func(path string, info os.FileInfo, err error) error { //nolint:staticcheck
+	err := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error { //nolint:staticcheck
 		if info == nil || info.IsDir() {
 			return nil
 		}
@@ -292,7 +289,7 @@ func (o *Options) moveFilesToClusterOrNamespacesFolder(dir, ns, releaseName, cha
 		if kyamls.IsCustomResourceDefinition(kind) {
 			outDir = filepath.Join(o.CustomResourceDefinitionsDir, ns, pathName)
 		} else {
-			isClusterKind, err := o.isClusterWide(kind, kyamls.GetAPIVersion(node, path), JXClient)
+			isClusterKind, err := o.isClusterWide(kind)
 			if err != nil {
 				return err
 			}
@@ -330,25 +327,32 @@ func (o *Options) moveFilesToClusterOrNamespacesFolder(dir, ns, releaseName, cha
 	return nil
 }
 
-func (o *Options) isClusterWide(kind string, apiVersion string, client versioned.Interface) (bool, error) {
+func (o *Options) isClusterWide(kind string) (bool, error) {
 	if kube.IsNoKubernetes() {
 		// Approximates the truth
 		return kyamls.IsClusterKind(kind), nil
 	}
-	val, ok := o.ClusterWide[kind]
-	if !ok {
-		apiResourceList, err := client.Discovery().ServerResourcesForGroupVersion(apiVersion)
+	if o.ClusterWide == nil {
+		o.ClusterWide = make(map[string]bool)
+		client, err := jxclient.LazyCreateJXClient(nil)
 		if err != nil {
-			return true, err
+			return kyamls.IsClusterKind(kind), errors.Wrapf(err, "Failed to create k8s client")
+		}
+		apiResourceLists, err := client.Discovery().ServerPreferredResources()
+		if err != nil {
+			return kyamls.IsClusterKind(kind), errors.Wrapf(err, "Failed to fetch api resources")
 		}
 
-		for _, resource := range apiResourceList.APIResources {
-			o.ClusterWide[resource.Kind] = !resource.Namespaced
-		}
-		val, ok = o.ClusterWide[kind]
-		if !ok {
-			return false, fmt.Errorf("the server doesn't have %s of %s", kind, apiVersion)
+		for _, apiResourceList := range apiResourceLists {
+			for _, resource := range apiResourceList.APIResources {
+				o.ClusterWide[resource.Kind] = !resource.Namespaced
+			}
 		}
 	}
+	val, ok := o.ClusterWide[kind]
+	if !ok {
+		return false, fmt.Errorf("the server doesn't have resource of kind %s", kind)
+	}
+
 	return val, nil
 }


### PR DESCRIPTION
Don't bother about fetching version in manifest, it often lacks in the API. This means it fails with the `server could not find the requested resource`. This method might be slower since all resources are fetched, but that is better than failing.