### PR TITLE
fix: pr comment variables

### DIFF
--- a/pkg/cmd/pr/variables/variables.go
+++ b/pkg/cmd/pr/variables/variables.go
@@ -180,7 +180,7 @@ func (o *Options) loadPRComments(envVars map[string]string, pr *scm.PullRequest)
 	ctx := o.GetContext()
 	prNumber := pr.Number
 	opts := scm.ListOptions{}
-	comments, _, err := o.ScmClient.PullRequests.ListComments(ctx, o.Repository, prNumber, opts)
+	comments, _, err := o.ScmClient.PullRequests.ListComments(ctx, o.FullRepositoryName, prNumber, opts)
 	if err != nil {
 		return errors.Wrapf(err, "failed to list comments of PR %d", prNumber)
 	}


### PR DESCRIPTION
This PR is the newly rebased version of this https://github.com/jenkins-x-plugins/jx-gitops/pull/805
This should fix the problem where trying to use  ` jx gitops pr variables --comments` - fails with 
```
error: failed to load variables from PR comments: failed to list comments of PR 91: Not Found
```

