### PR TITLE
chore: add GetFilteredGroups GetRepository GetRepositoryFor

### DIFF
--- a/pkg/sourceconfigs/helpers.go
+++ b/pkg/sourceconfigs/helpers.go
@@ -135,6 +135,18 @@ func DefaultValues(config *v1alpha1.SourceConfig, group *v1alpha1.RepositoryGrou
 	return nil
 }
 
+// GetFilteredGroups get the groups for the given git kind & server URL if specified and owner
+func GetFilteredGroups(groups []v1alpha1.RepositoryGroup, gitKind, gitServerURL, owner string) []v1alpha1.RepositoryGroup {
+	var filteredGroups []v1alpha1.RepositoryGroup
+	for _, group := range groups {
+		if (group.ProviderKind == gitKind || gitKind == "") && (group.Provider == gitServerURL || gitServerURL == "") && strings.EqualFold(group.Owner, owner) {
+			filteredGroups = append(filteredGroups, group)
+		}
+	}
+
+	return filteredGroups
+}
+
 // GetOrCreateGroup get or create the group for the given name
 func GetOrCreateGroup(config *v1alpha1.SourceConfig, gitKind, gitServerURL, owner string) *v1alpha1.RepositoryGroup {
 	var group *v1alpha1.RepositoryGroup
@@ -169,6 +181,26 @@ func getOrCreateGroup(groups []v1alpha1.RepositoryGroup, gitKind, gitServerURL, 
 func GetOrCreateRepositoryFor(config *v1alpha1.SourceConfig, gitServerURL, owner, repo string) *v1alpha1.Repository {
 	group := GetOrCreateGroup(config, "", gitServerURL, owner)
 	return GetOrCreateRepository(group, repo)
+}
+
+// GetRepositoryFor returns the repository for the given git server URL if specified, owner and given repo name
+func GetRepositoryFor(config *v1alpha1.SourceConfig, gitServerURL, owner, repo string) *v1alpha1.Repository {
+	groups := GetFilteredGroups(config.Spec.Groups, "", gitServerURL, owner)
+	return GetRepository(groups, repo)
+}
+
+// GetRepository get the repository for the given name
+func GetRepository(groups []v1alpha1.RepositoryGroup, repoName string) *v1alpha1.Repository {
+	for _, group := range groups {
+		for r := range group.Repositories {
+			repo := &group.Repositories[r]
+			if repo.Name == repoName {
+				return repo
+			}
+		}
+	}
+
+	return nil
 }
 
 // GetOrCreateRepository get or create the repository for the given name

--- a/pkg/sourceconfigs/helpers.go
+++ b/pkg/sourceconfigs/helpers.go
@@ -138,9 +138,10 @@ func DefaultValues(config *v1alpha1.SourceConfig, group *v1alpha1.RepositoryGrou
 // GetFilteredGroups get the groups for the given git kind & server URL if specified and owner
 func GetFilteredGroups(groups []v1alpha1.RepositoryGroup, gitKind, gitServerURL, owner string) []v1alpha1.RepositoryGroup {
 	var filteredGroups []v1alpha1.RepositoryGroup
-	for _, group := range groups {
+	for g := range groups {
+		group := &groups[g]
 		if (group.ProviderKind == gitKind || gitKind == "") && (group.Provider == gitServerURL || gitServerURL == "") && strings.EqualFold(group.Owner, owner) {
-			filteredGroups = append(filteredGroups, group)
+			filteredGroups = append(filteredGroups, *group)
 		}
 	}
 
@@ -191,7 +192,8 @@ func GetRepositoryFor(config *v1alpha1.SourceConfig, gitServerURL, owner, repo s
 
 // GetRepository get the repository for the given name
 func GetRepository(groups []v1alpha1.RepositoryGroup, repoName string) *v1alpha1.Repository {
-	for _, group := range groups {
+	for g := range groups {
+		group := &groups[g]
 		for r := range group.Repositories {
 			repo := &group.Repositories[r]
 			if repo.Name == repoName {

--- a/pkg/sourceconfigs/helpers_test.go
+++ b/pkg/sourceconfigs/helpers_test.go
@@ -116,6 +116,16 @@ func TestSourceConfigGlobalDefaultValues(t *testing.T) {
 						},
 					},
 				},
+				{
+					Provider:     gitServer,
+					ProviderKind: gitKind,
+					Owner:        owner,
+					Repositories: []v1alpha1.Repository{
+						{
+							Name: "myrepo2",
+						},
+					},
+				},
 			},
 			Slack: &v1alpha1.SlackNotify{
 				Channel:  "my-channel",
@@ -128,11 +138,12 @@ func TestSourceConfigGlobalDefaultValues(t *testing.T) {
 	require.NoError(t, err)
 
 	assertSlackChannel(t, config, owner, "myrepo", "my-channel", v1alpha1.PipelineKindAll, false, false)
+	assertSlackChannel(t, config, owner, "myrepo2", "my-channel", v1alpha1.PipelineKindAll, false, false)
 }
 
 func assertSlackChannel(t *testing.T, config *v1alpha1.SourceConfig, owner, repoName, expectedChannel string, expectedPipeline v1alpha1.PipelineKind, expectedDirectMessage, expectedNotifyReviewers bool) {
-	group := sourceconfigs.GetOrCreateGroup(config, gitKind, gitServer, owner)
-	repo := sourceconfigs.GetOrCreateRepository(group, repoName)
+	groups := sourceconfigs.GetFilteredGroups(config.Spec.Groups, gitKind, gitServer, owner)
+	repo := sourceconfigs.GetRepository(groups, repoName)
 	require.NotNil(t, repo, "should have found a repo for owner %s and repo %s", owner, repoName)
 	slack := repo.Slack
 	require.NotNil(t, slack, "no slack configuration found for owner %s and repo %s", owner, repoName)

--- a/pkg/sourceconfigs/helpers_test.go
+++ b/pkg/sourceconfigs/helpers_test.go
@@ -90,6 +90,8 @@ func TestSourceConfigDefaultValues(t *testing.T) {
 	err := sourceconfigs.DefaultConfigValues(config)
 	require.NoError(t, err)
 
+	assertSlackChannel(t, config, "non-existing-owner", "non-existing-repo", "", v1alpha1.PipelineKindAll, false, false, false)
+
 	assertSlackChannel(t, config, owner, "no-cfg", "default-channel", v1alpha1.PipelineKindRelease, false, true, true)
 	assertSlackChannel(t, config, owner, "override-channel", "new-channel", v1alpha1.PipelineKindAll, false, true, true)
 

--- a/pkg/sourceconfigs/helpers_test.go
+++ b/pkg/sourceconfigs/helpers_test.go
@@ -90,18 +90,28 @@ func TestSourceConfigDefaultValues(t *testing.T) {
 	err := sourceconfigs.DefaultConfigValues(config)
 	require.NoError(t, err)
 
-	assertSlackChannel(t, config, owner, "no-cfg", "default-channel", v1alpha1.PipelineKindRelease, false, true)
-	assertSlackChannel(t, config, owner, "override-channel", "new-channel", v1alpha1.PipelineKindAll, false, true)
+	assertSlackChannel(t, config, owner, "no-cfg", "default-channel", v1alpha1.PipelineKindRelease, false, true, true)
+	assertSlackChannel(t, config, owner, "override-channel", "new-channel", v1alpha1.PipelineKindAll, false, true, true)
 
-	assertSlackChannel(t, config, "default-disabled", "default-value", "default-channel", v1alpha1.PipelineKindRelease, true, true)
-	assertSlackChannel(t, config, "default-disabled", "repo-enabled", "default-channel", v1alpha1.PipelineKindRelease, false, true)
+	assertSlackChannel(t, config, "default-disabled", "default-value", "default-channel", v1alpha1.PipelineKindRelease, true, true, true)
+	assertSlackChannel(t, config, "default-disabled", "repo-enabled", "default-channel", v1alpha1.PipelineKindRelease, false, true, true)
 
-	assertSlackChannel(t, config, "no-cfg", "default-value", "default-channel-for-orgs", v1alpha1.PipelineKindRelease, false, true)
-	assertSlackChannel(t, config, "no-cfg", "repo-enabled", "default-channel-for-orgs", v1alpha1.PipelineKindRelease, false, false)
+	assertSlackChannel(t, config, "no-cfg", "default-value", "default-channel-for-orgs", v1alpha1.PipelineKindRelease, false, true, true)
+	assertSlackChannel(t, config, "no-cfg", "repo-enabled", "default-channel-for-orgs", v1alpha1.PipelineKindRelease, false, false, true)
 }
 
 func TestSourceConfigGlobalDefaultValues(t *testing.T) {
 	owner := "myowner"
+
+	nonGroupConfig := &v1alpha1.SourceConfig{
+		Spec: v1alpha1.SourceConfigSpec{
+			Groups: []v1alpha1.RepositoryGroup{},
+			Slack: &v1alpha1.SlackNotify{
+				Channel:  "my-channel",
+				Pipeline: v1alpha1.PipelineKindAll,
+			},
+		},
+	}
 
 	config := &v1alpha1.SourceConfig{
 		Spec: v1alpha1.SourceConfigSpec{
@@ -137,18 +147,22 @@ func TestSourceConfigGlobalDefaultValues(t *testing.T) {
 	err := sourceconfigs.DefaultConfigValues(config)
 	require.NoError(t, err)
 
-	assertSlackChannel(t, config, owner, "myrepo", "my-channel", v1alpha1.PipelineKindAll, false, false)
-	assertSlackChannel(t, config, owner, "myrepo2", "my-channel", v1alpha1.PipelineKindAll, false, false)
+	assertSlackChannel(t, nonGroupConfig, "", "", "", v1alpha1.PipelineKindAll, false, false, false)
+	assertSlackChannel(t, config, owner, "myrepo2", "my-channel", v1alpha1.PipelineKindAll, false, false, true)
 }
 
-func assertSlackChannel(t *testing.T, config *v1alpha1.SourceConfig, owner, repoName, expectedChannel string, expectedPipeline v1alpha1.PipelineKind, expectedDirectMessage, expectedNotifyReviewers bool) {
+func assertSlackChannel(t *testing.T, config *v1alpha1.SourceConfig, owner, repoName, expectedChannel string, expectedPipeline v1alpha1.PipelineKind, expectedDirectMessage, expectedNotifyReviewers, expectedRepo bool) {
 	groups := sourceconfigs.GetFilteredGroups(config.Spec.Groups, gitKind, gitServer, owner)
 	repo := sourceconfigs.GetRepository(groups, repoName)
-	require.NotNil(t, repo, "should have found a repo for owner %s and repo %s", owner, repoName)
-	slack := repo.Slack
-	require.NotNil(t, slack, "no slack configuration found for owner %s and repo %s", owner, repoName)
-	assert.Equal(t, expectedChannel, slack.Channel, "slack channel for owner %s and repo %s", owner, repoName)
-	assert.Equal(t, expectedPipeline, slack.Pipeline, "slack pipeline for owner %s and repo %s", owner, repoName)
-	assert.Equal(t, expectedDirectMessage, slack.DirectMessage.ToBool(), "slack channel directMessage flag for owner %s and repo %s", owner, repoName)
-	assert.Equal(t, expectedNotifyReviewers, slack.NotifyReviewers.ToBool(), "slack channel notifyReviewers flag for owner %s and repo %s", owner, repoName)
+	if expectedRepo {
+		require.NotNil(t, repo, "should have found a repo for owner %s and repo %s", owner, repoName)
+		slack := repo.Slack
+		require.NotNil(t, slack, "no slack configuration found for owner %s and repo %s", owner, repoName)
+		assert.Equal(t, expectedChannel, slack.Channel, "slack channel for owner %s and repo %s", owner, repoName)
+		assert.Equal(t, expectedPipeline, slack.Pipeline, "slack pipeline for owner %s and repo %s", owner, repoName)
+		assert.Equal(t, expectedDirectMessage, slack.DirectMessage.ToBool(), "slack channel directMessage flag for owner %s and repo %s", owner, repoName)
+		assert.Equal(t, expectedNotifyReviewers, slack.NotifyReviewers.ToBool(), "slack channel notifyReviewers flag for owner %s and repo %s", owner, repoName)
+	} else {
+		require.Nil(t, repo, "should not have found a repo for owner %s and repo %s", owner, repoName)
+	}
 }

--- a/pkg/sourceconfigs/helpers_test.go
+++ b/pkg/sourceconfigs/helpers_test.go
@@ -152,8 +152,7 @@ func TestSourceConfigGlobalDefaultValues(t *testing.T) {
 }
 
 func assertSlackChannel(t *testing.T, config *v1alpha1.SourceConfig, owner, repoName, expectedChannel string, expectedPipeline v1alpha1.PipelineKind, expectedDirectMessage, expectedNotifyReviewers, expectedRepo bool) {
-	groups := sourceconfigs.GetFilteredGroups(config.Spec.Groups, gitKind, gitServer, owner)
-	repo := sourceconfigs.GetRepository(groups, repoName)
+	repo := sourceconfigs.GetRepositoryFor(config, "", owner, repoName)
 	if expectedRepo {
 		require.NotNil(t, repo, "should have found a repo for owner %s and repo %s", owner, repoName)
 		slack := repo.Slack


### PR DESCRIPTION
Issue from jx-slack where it doesn't find configuration for one of my repositories

I have repositories, splitted into 2 different groups just because it doesn't use the same scheduler

on the case the kind, gitserver url and owner is the same on both group, the function GetOrCreateGroup will just take the first group, even if my repository is on the second one

in order to fix this I have- create Get only function in order to get the right repository on jx-slack