### PR TITLE
chore(deps): Upgrade kpt

### DIFF
--- a/pkg/plugins/versions.go
+++ b/pkg/plugins/versions.go
@@ -28,7 +28,7 @@ const (
 	HelmfileVersion = "0.143.0"
 
 	// KptVersion the default version of kpt to use
-	KptVersion = "0.37.0"
+	KptVersion = "1.0.0-beta.17"
 
 	// KubectlVersion the default version of kpt to use
 	KubectlVersion = "1.21.0"


### PR DESCRIPTION
I can't see in the docs that there are any breaking changes for kpt pkg, which as far as I know is the only functionality currently used by Jenkins-X. But I plan to use kpt live to solve jenkins-x/jx#8024 and those commands have breaking changes, so it would be easier to upgrade before starting to use that functionality.