### PR TITLE
fix:  ListComments order of gitlab

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/h2non/gock v1.0.9
 	github.com/imdario/mergo v0.3.12
 	github.com/jenkins-x-plugins/jx-charter v0.0.28
-	github.com/jenkins-x/go-scm v1.11.5
+	github.com/jenkins-x/go-scm v1.11.15
 	github.com/jenkins-x/jx-api/v4 v4.3.5
 	github.com/jenkins-x/jx-helpers/v3 v3.2.5
 	github.com/jenkins-x/jx-kube-client/v3 v3.0.2
@@ -241,7 +241,7 @@ replace (
 	//knative.dev/pkg => knative.dev/pkg v0.0.0-20210730172132-bb4aaf09c430
 
 	// override the go-scm from tekton
-	github.com/jenkins-x/go-scm => github.com/jenkins-x/go-scm v1.11.5
+	github.com/jenkins-x/go-scm => github.com/jenkins-x/go-scm v1.11.15
 
 	// for the PipelineRun debug fix see: https://github.com/tektoncd/pipeline/pull/4145
 	github.com/tektoncd/pipeline => github.com/jstrachan/pipeline v0.21.1-0.20210811150720-45a86a5488af

--- a/go.sum
+++ b/go.sum
@@ -744,8 +744,8 @@ github.com/jehiah/go-strftime v0.0.0-20171201141054-1d33003b3869/go.mod h1:cJ6Cj
 github.com/jenkins-x-plugins/jx-charter v0.0.28 h1:Pwtcm2L8+xmtboPBIvTsc3jPLEwZuYnzDtBQurdVuv0=
 github.com/jenkins-x-plugins/jx-charter v0.0.28/go.mod h1:oWhIpQIRc08qikMIH7VF08kQM/onYtU9teWq8eCSaJE=
 github.com/jenkins-x/gen-crd-api-reference-docs v0.1.6/go.mod h1:a4dzSf/nNLMMMqultm6IlV/04xq26uICEYPkSTOahWQ=
-github.com/jenkins-x/go-scm v1.11.5 h1:bWfyBlcDB/HHSRmJOSmBs2l4VRL2YF1Ka6Y1dn4Inx0=
-github.com/jenkins-x/go-scm v1.11.5/go.mod h1:GB6XjszezsDOxKTsPoyk4MT/cKw30qkPdJ4tml+MImg=
+github.com/jenkins-x/go-scm v1.11.15 h1:g9ctK8WvB392jSF12lDbGTU/Jf54cKsVgNXFHU/ZCTc=
+github.com/jenkins-x/go-scm v1.11.15/go.mod h1:GB6XjszezsDOxKTsPoyk4MT/cKw30qkPdJ4tml+MImg=
 github.com/jenkins-x/jx-api/v4 v4.1.5/go.mod h1:l11kHlFy40UGu9pdhCRxDiJcEgRubSVzybWB2jXjLcs=
 github.com/jenkins-x/jx-api/v4 v4.3.3/go.mod h1:l11kHlFy40UGu9pdhCRxDiJcEgRubSVzybWB2jXjLcs=
 github.com/jenkins-x/jx-api/v4 v4.3.5 h1:B+K9DKCtCYyYteDaHGmZrBUKkuUULHPFwKQc3j16ECA=

--- a/pkg/cmd/pr/variables/variables.go
+++ b/pkg/cmd/pr/variables/variables.go
@@ -179,7 +179,9 @@ func (o *Options) modifyVariables(text string) error {
 func (o *Options) loadPRComments(envVars map[string]string, pr *scm.PullRequest) error {
 	ctx := o.GetContext()
 	prNumber := pr.Number
-	opts := scm.ListOptions{}
+	opts := scm.ListOptions{
+		Sort: "asc",
+	}
 	comments, _, err := o.ScmClient.PullRequests.ListComments(ctx, o.FullRepositoryName, prNumber, opts)
 	if err != nil {
 		return errors.Wrapf(err, "failed to list comments of PR %d", prNumber)


### PR DESCRIPTION
Fix the issue of listcomments reading order in gitlab so that the latest variables can be read