### PR TITLE
fix: Resources for release build

### DIFF
--- a/.lighthouse/jenkins-x/release.yaml
+++ b/.lighthouse/jenkins-x/release.yaml
@@ -25,7 +25,7 @@ spec:
               cpu: 4
               memory: 2Gi
             requests:
-              cpu: 2
+              cpu: 1
               memory: 1Gi
         - name: jx-variables
           resources: {}


### PR DESCRIPTION
Trying to fix that goreleaser times out