### PR TITLE
fix: Only upgrade pkg with upstream

### DIFF
--- a/pkg/cmd/kpt/update/update.go
+++ b/pkg/cmd/kpt/update/update.go
@@ -278,10 +278,6 @@ func (o *Options) handleKptfileConflictsAndContinue(dir string, lines []string) 
 
 // Matches returns true if this kpt file matches the filters
 func (o *Options) Matches(path string) (bool, error) {
-	if o.RepositoryName == "" && o.RepositoryOwner == "" && o.RepositoryURL == "" {
-		return true, nil
-	}
-
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return false, errors.Wrapf(err, "failed to load file %s", path)

--- a/pkg/cmd/kpt/update/update.go
+++ b/pkg/cmd/kpt/update/update.go
@@ -292,7 +292,7 @@ func (o *Options) Matches(path string) (bool, error) {
 	repoPath := "upstream.git.repo"
 	repo := maps.GetMapValueAsStringViaPath(obj.Object, repoPath)
 	if repo == "" {
-		log.Logger().Warnf("could not find field %s in file %s", repoPath, path)
+		log.Logger().Debugf("could not find field %s in file %s", repoPath, path)
 		return false, nil
 	}
 	if o.RepositoryURL != "" {


### PR DESCRIPTION
This is part of solving jenkins-x/jx#8024

Got this error during `jx gitops upgrade`:

```
processing kpt directory: config-root wth strategy: resource-merge
error: failed to update source using kpt: failed to upgrade kpt packages in dir /Users/msv/Documents/projects/jx3-cluster-dev: failed to run kpt command: failed to run '/Users/msv/.jx-gitops/plugins/bin/kpt-1.0.0-beta.17 pkg update config-root@ --strategy resource-merge' command in directory '/Users/msv/Documents/projects/jx3-cluster-dev', output: 'Error: package must have an upstream reference'
```

This is since this package isn't referring a to an upstream package, which it shouldn't. (It's used for `kpt live apply`.) The fix makes the check for the upstreams repo execute.