### PR TITLE
chore: upgrade helmfile plugin binary to 0.144.0

### DIFF
--- a/pkg/plugins/versions.go
+++ b/pkg/plugins/versions.go
@@ -25,7 +25,7 @@ const (
 	HelmVersion = "3.7.2"
 
 	// HelmfileVersion the default version of helmfile to use
-	HelmfileVersion = "0.143.0"
+	HelmfileVersion = "0.144.0"
 
 	// KptVersion the default version of kpt to use
 	KptVersion = "1.0.0-beta.17"


### PR DESCRIPTION
While we wait for the upstream helmfile/helmfile repo to stabilize for https://github.com/jenkins-x-plugins/jx-gitops/pull/869, I'd like to leverage the `--skip-tests` feature released in [version 0.143.1](https://github.com/roboll/helmfile/releases/tag/v0.143.1). 0.144.0 is the most recent version available from the roboll/helmfile remote.

ref https://github.com/jenkins-x/jx3-versions/pull/3306