### PR TITLE
fix: Regen on new cluster

### DIFF
--- a/pkg/cmd/apply/apply.go
+++ b/pkg/cmd/apply/apply.go
@@ -1,9 +1,11 @@
 package apply
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	"github.com/jenkins-x-plugins/jx-gitops/pkg/rootcmd"
@@ -12,11 +14,13 @@ import (
 	"github.com/jenkins-x/jx-helpers/v3/pkg/cobras/templates"
 	"github.com/jenkins-x/jx-helpers/v3/pkg/gitclient"
 	"github.com/jenkins-x/jx-helpers/v3/pkg/gitclient/cli"
+	"github.com/jenkins-x/jx-helpers/v3/pkg/kube"
 	"github.com/jenkins-x/jx-helpers/v3/pkg/termcolor"
 	"github.com/jenkins-x/jx-helpers/v3/pkg/yamls"
 	"github.com/jenkins-x/jx-logging/v3/pkg/log"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
@@ -26,7 +30,7 @@ var (
 	cmdLong = templates.LongDesc(`
 		Performs a gitops regeneration and apply on a cluster git repository
 
-		If the last commit was a merge from a pull request the regeneration is skipped.
+		If the last commit was a merge from a pull request the regeneration is skipped, unless the cluster is new.
 
 		Also the process detects if an ingress has changed (or similar changes) and retriggers another regeneration which typically is only required when installing for the first time or if no explicit domain name is being used and the LoadBalancer service has been removed.
 `)
@@ -44,6 +48,7 @@ type Options struct {
 	GitClient        gitclient.Interface
 	CommandRunner    cmdrunner.CommandRunner
 	GitCommandRunner cmdrunner.CommandRunner
+	IsNewCluster     bool
 }
 
 // NewCmdApply creates a command object for the command
@@ -73,6 +78,7 @@ func (o *Options) Validate() error {
 	if o.GitClient == nil {
 		o.GitClient = cli.NewCLIClient("", o.CommandRunner)
 	}
+	o.IsNewCluster = o.isNewCluster()
 	return nil
 }
 
@@ -90,7 +96,7 @@ func (o *Options) Run() error {
 	lastCommitMessage = strings.TrimSpace(lastCommitMessage)
 	log.Logger().Infof("found last commit message: %s", termcolor.ColorStatus(lastCommitMessage))
 
-	if strings.Contains(lastCommitMessage, "/pipeline cancel") {
+	if strings.Contains(lastCommitMessage, "/pipeline cancel") && !o.IsNewCluster {
 		log.Logger().Infof("last commit disabled further processing")
 		return nil
 	}
@@ -107,6 +113,8 @@ func (o *Options) Run() error {
 		}
 		if changedExternalSecret {
 			log.Logger().Infof("last commit changed an ExternalSecret so still performing a full regenerate")
+		} else if o.IsNewCluster {
+			log.Logger().Infof("applying to new cluster so performing a full regenerate")
 		} else {
 			log.Logger().Infof("last commit was a merge pull request without changing an ExternalSecret so not regenerating")
 			regen = false
@@ -122,7 +130,7 @@ func (o *Options) Run() error {
 		c := &cmdrunner.Command{
 			Dir:  o.Dir,
 			Name: "make",
-			Args: []string{"regen-phase-3"},
+			Args: []string{"regen-phase-3", "NEW_CLUSTER=" + strconv.FormatBool(o.IsNewCluster)},
 		}
 		err = o.RunCommand(c)
 		if err != nil {
@@ -152,7 +160,7 @@ func (o *Options) Regenerate() (bool, error) {
 	c := &cmdrunner.Command{
 		Dir:  o.Dir,
 		Name: "make",
-		Args: []string{"regen-phase-1"},
+		Args: []string{"regen-phase-1", "NEW_CLUSTER=" + strconv.FormatBool(o.IsNewCluster)},
 	}
 	err = o.RunCommand(c)
 	if err != nil {
@@ -179,7 +187,7 @@ func (o *Options) Regenerate() (bool, error) {
 	c = &cmdrunner.Command{
 		Dir:  o.Dir,
 		Name: "make",
-		Args: []string{"regen-phase-2"},
+		Args: []string{"regen-phase-2", "NEW_CLUSTER=" + strconv.FormatBool(o.IsNewCluster)},
 	}
 	err = o.RunCommand(c)
 	if err != nil {
@@ -238,4 +246,28 @@ func (o *Options) CheckLastCommitChangedExternalSecret(gitter gitclient.Interfac
 		log.Logger().Debugf("ignoring kind %s in file %s", kind, path)
 	}
 	return false, nil
+}
+
+func (o *Options) isNewCluster() bool {
+	client, err := kube.LazyCreateKubeClientWithMandatory(nil, true)
+	if err != nil {
+		log.Logger().Errorf("Failed to create k8s client. Assuming this is a neww cluster: %v", err)
+		return true
+	}
+	// If label team=jx is not set on namespace jx the cluster is considered new, as in that the jx-boot job has not run
+	ns, err := client.CoreV1().Namespaces().Get(context.TODO(), "jx", metav1.GetOptions{})
+	if err != nil {
+		log.Logger().Infof("Can't find namespace jx. Assuming this is a new cluster: %v", err)
+		return true
+	}
+	team, ok := ns.GetLabels()["team"]
+	if !ok {
+		log.Logger().Infof("Label team not found on namespace jx. Assuming this is a new cluster.")
+		return true
+	}
+	if team != "jx" {
+		log.Logger().Infof("Label team not set to jx on namespace jx. Assuming this is a new cluster.")
+		return true
+	}
+	return false
 }


### PR DESCRIPTION
Fixes https://github.com/jenkins-x/jx3-versions/issues/2731

I also added NEW_CLUSTER variable for regen targets which will be useful for https://github.com/jenkins-x/jx3-versions/pull/3223

This is  a new attempt after #876 had to be reverted