### PR TITLE
Support OCI in helm charts with dependencies

### DIFF
--- a/Dockerfile-preview
+++ b/Dockerfile-preview
@@ -1,3 +1,5 @@
-FROM ghcr.io/jenkins-x/jx-cli:latest
+FROM ghcr.io/jenkins-x/jx-boot:latest
+
+ENTRYPOINT ["jx-gitops"]
 
 COPY ./build/linux/jx-gitops /usr/bin/jx-gitops

--- a/pkg/cmd/helm/build/build.go
+++ b/pkg/cmd/helm/build/build.go
@@ -42,7 +42,6 @@ type Options struct {
 	ChartsDir          string
 	OCI                bool
 	RegistryConfigFile string
-	NoOCILogin         bool
 	RepositoryUsername string
 	RepositoryPassword string
 	RepositoryURL      string

--- a/pkg/cmd/helm/build/build.go
+++ b/pkg/cmd/helm/build/build.go
@@ -39,6 +39,7 @@ type Options struct {
 	UseHelmPlugin bool
 	HelmBinary    string
 	ChartsDir     string
+	NoHelmRepoAdd bool
 	CommandRunner cmdrunner.CommandRunner
 }
 
@@ -59,6 +60,8 @@ func NewCmdHelmBuild() (*cobra.Command, *Options) {
 	cmd.Flags().StringVarP(&o.ChartsDir, "charts-dir", "c", "charts", "the directory to look for helm charts to release")
 	cmd.Flags().StringVarP(&o.HelmBinary, "binary", "n", "", "specifies the helm binary location to use. If not specified defaults to 'helm' on the $PATH")
 	cmd.Flags().BoolVarP(&o.UseHelmPlugin, "use-helm-plugin", "", false, "uses the jx binary plugin for helm rather than whatever helm is on the $PATH")
+	cmd.Flags().BoolVarP(&o.NoHelmRepoAdd, "no-helm-repo-add", "", false, "disables using the 'helm repo add' command")
+
 	return cmd, o
 }
 

--- a/pkg/cmd/helm/build/build_test.go
+++ b/pkg/cmd/helm/build/build_test.go
@@ -22,14 +22,13 @@ func TestStepHelmBuildWithCharts(t *testing.T) {
 	o.HelmBinary = helmBin
 	o.CommandRunner = runner.Run
 	o.ChartsDir = filepath.Join(path, "charts")
-	o.Version = "0.2"
 
 	err := o.Run()
 	require.NoError(t, err, "failed to run the command")
 
 	runner.ExpectResults(t,
 		fakerunner.FakeResult{
-			CLI: "helm repo add 0 file://../myapp-common",
+			CLI: "helm repo add 0 file://myapp-common",
 		},
 
 		fakerunner.FakeResult{
@@ -39,7 +38,7 @@ func TestStepHelmBuildWithCharts(t *testing.T) {
 			CLI: "helm dependency build .",
 		},
 		fakerunner.FakeResult{
-			CLI: "helm package . --version " + o.Version,
+			CLI: "helm package .",
 		},
 	)
 
@@ -57,7 +56,6 @@ func TestStepHelmBuildWithChartsOCI(t *testing.T) {
 	o.HelmBinary = helmBin
 	o.CommandRunner = runner.Run
 	o.ChartsDir = filepath.Join(path, "charts")
-	o.Version = "0.2"
 	o.OCI = true
 
 	err := o.Run()
@@ -65,13 +63,16 @@ func TestStepHelmBuildWithChartsOCI(t *testing.T) {
 
 	runner.ExpectResults(t,
 		fakerunner.FakeResult{
+			CLI: "helm repo add 0 file://myapp-common",
+		},
+		fakerunner.FakeResult{
 			CLI: "helm lint",
 		},
 		fakerunner.FakeResult{
 			CLI: "helm dependency build . --registry-config " + o.RegistryConfigFile,
 		},
 		fakerunner.FakeResult{
-			CLI: "helm package . --version " + o.Version + " --registry-config " + o.RegistryConfigFile,
+			CLI: "helm package . --registry-config " + o.RegistryConfigFile,
 		},
 	)
 
@@ -89,7 +90,6 @@ func TestStepHelmBuildWithChartsOCIPassword(t *testing.T) {
 	o.HelmBinary = helmBin
 	o.CommandRunner = runner.Run
 	o.ChartsDir = filepath.Join(path, "charts")
-	o.Version = "0.2"
 	o.OCI = true
 	o.RepositoryPassword = "xxx"
 	o.RepositoryUsername = "fish"
@@ -98,6 +98,9 @@ func TestStepHelmBuildWithChartsOCIPassword(t *testing.T) {
 	require.NoError(t, err, "failed to run the command")
 
 	runner.ExpectResults(t,
+		fakerunner.FakeResult{
+			CLI: "helm repo add 0 file://myapp-common",
+		},
 		fakerunner.FakeResult{
 			CLI: "helm lint",
 		},
@@ -109,7 +112,7 @@ func TestStepHelmBuildWithChartsOCIPassword(t *testing.T) {
 			CLI: "helm dependency build .",
 		},
 		fakerunner.FakeResult{
-			CLI: "helm package . --version " + o.Version,
+			CLI: "helm package .",
 		},
 	)
 

--- a/pkg/cmd/helm/build/build_test.go
+++ b/pkg/cmd/helm/build/build_test.go
@@ -1,44 +1,135 @@
 package build_test
 
 import (
-	"os"
+	"fmt"
 	"path/filepath"
 	"testing"
 
 	"github.com/jenkins-x-plugins/jx-gitops/pkg/cmd/helm/build"
 	"github.com/jenkins-x/jx-helpers/v3/pkg/cmdrunner/fakerunner"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-func TestStepHelmBuild(t *testing.T) {
+func TestStepHelmBuildWithCharts(t *testing.T) {
 	sourceData := "testdata"
-	fileNames, err := os.ReadDir(sourceData)
-	assert.NoError(t, err)
 
-	for _, f := range fileNames {
-		if !f.IsDir() {
-			continue
-		}
-		name := f.Name()
-		path := filepath.Join(sourceData, name)
+	path := filepath.Join(sourceData, "has_charts")
 
-		t.Logf("running test dir %s", name)
+	runner := &fakerunner.FakeRunner{}
+	helmBin := "helm"
 
-		runner := &fakerunner.FakeRunner{}
-		helmBin := "helm"
+	_, o := build.NewCmdHelmBuild()
+	o.HelmBinary = helmBin
+	o.CommandRunner = runner.Run
+	o.ChartsDir = filepath.Join(path, "charts")
+	o.Version = "0.2"
 
-		_, o := build.NewCmdHelmBuild()
-		o.HelmBinary = helmBin
-		o.CommandRunner = runner.Run
-		o.ChartsDir = filepath.Join(path, "charts")
+	err := o.Run()
+	require.NoError(t, err, "failed to run the command")
 
-		err = o.Run()
-		require.NoError(t, err, "failed to run the command for dir %s", name)
+	runner.ExpectResults(t,
+		fakerunner.FakeResult{
+			CLI: "helm repo add 0 file://../myapp-common",
+		},
 
-		for _, c := range runner.OrderedCommands {
-			t.Logf("ran: %s\n", c.CLI())
-		}
+		fakerunner.FakeResult{
+			CLI: "helm lint",
+		},
+		fakerunner.FakeResult{
+			CLI: "helm dependency build .",
+		},
+		fakerunner.FakeResult{
+			CLI: "helm package . --version " + o.Version,
+		},
+	)
 
-	}
+}
+
+func TestStepHelmBuildWithChartsOCI(t *testing.T) {
+	sourceData := "testdata"
+
+	path := filepath.Join(sourceData, "has_charts")
+
+	runner := &fakerunner.FakeRunner{}
+	helmBin := "helm"
+
+	_, o := build.NewCmdHelmBuild()
+	o.HelmBinary = helmBin
+	o.CommandRunner = runner.Run
+	o.ChartsDir = filepath.Join(path, "charts")
+	o.Version = "0.2"
+	o.OCI = true
+
+	err := o.Run()
+	require.NoError(t, err, "failed to run the command")
+
+	runner.ExpectResults(t,
+		fakerunner.FakeResult{
+			CLI: "helm lint",
+		},
+		fakerunner.FakeResult{
+			CLI: "helm dependency build . --registry-config " + o.RegistryConfigFile,
+		},
+		fakerunner.FakeResult{
+			CLI: "helm package . --version " + o.Version + " --registry-config " + o.RegistryConfigFile,
+		},
+	)
+
+}
+
+func TestStepHelmBuildWithChartsOCIPassword(t *testing.T) {
+	sourceData := "testdata"
+
+	path := filepath.Join(sourceData, "has_charts")
+
+	runner := &fakerunner.FakeRunner{}
+	helmBin := "helm"
+
+	_, o := build.NewCmdHelmBuild()
+	o.HelmBinary = helmBin
+	o.CommandRunner = runner.Run
+	o.ChartsDir = filepath.Join(path, "charts")
+	o.Version = "0.2"
+	o.OCI = true
+	o.RepositoryPassword = "xxx"
+	o.RepositoryUsername = "fish"
+
+	err := o.Run()
+	require.NoError(t, err, "failed to run the command")
+
+	runner.ExpectResults(t,
+		fakerunner.FakeResult{
+			CLI: "helm lint",
+		},
+		fakerunner.FakeResult{
+			CLI: "helm registry login  --username fish --password xxx",
+		},
+
+		fakerunner.FakeResult{
+			CLI: "helm dependency build .",
+		},
+		fakerunner.FakeResult{
+			CLI: "helm package . --version " + o.Version,
+		},
+	)
+
+}
+
+func TestStepHelmBuildWithNoCharts(t *testing.T) {
+	sourceData := "testdata"
+
+	path := filepath.Join(sourceData, "no_charts")
+
+	runner := &fakerunner.FakeRunner{}
+	helmBin := "helm"
+
+	_, o := build.NewCmdHelmBuild()
+	o.HelmBinary = helmBin
+	o.CommandRunner = runner.Run
+	o.ChartsDir = filepath.Join(path, "charts")
+
+	err := o.Run()
+	require.NoError(t, err, "failed to run the command")
+	fmt.Printf("runner.ResultOutput: %v\n", runner.ResultOutput)
+
 }

--- a/pkg/cmd/helm/build/testdata/has_charts/charts/myapp/Chart.yaml
+++ b/pkg/cmd/helm/build/testdata/has_charts/charts/myapp/Chart.yaml
@@ -6,4 +6,7 @@ version: 0.1.0-SNAPSHOT
 dependencies:
   - name: myapp-common
     version: 0.1.0-SNAPSHOT
-    repository: file://../myapp-common
+    repository: file://myapp-common
+  - name: myapp-uncommon
+    version: 0.1.0-SNAPSHOT
+    repository: oci://myapp-uncommon

--- a/pkg/cmd/helm/build/testdata/has_charts/charts/myapp/Chart.yaml
+++ b/pkg/cmd/helm/build/testdata/has_charts/charts/myapp/Chart.yaml
@@ -1,5 +1,9 @@
-apiVersion: v1
+apiVersion: v2
 description: A Helm chart for Kubernetes
 icon: https://raw.githubusercontent.com/jenkins-x/jenkins-x-platform/d273e09/images/nodejs.png
 name: myapp
 version: 0.1.0-SNAPSHOT
+dependencies:
+  - name: myapp-common
+    version: 0.1.0-SNAPSHOT
+    repository: file://../myapp-common

--- a/pkg/cmd/helm/release/release.go
+++ b/pkg/cmd/helm/release/release.go
@@ -564,7 +564,7 @@ func (o *Options) BuildAndPackage(chartDir string) error {
 	c := &cmdrunner.Command{
 		Dir:  chartDir,
 		Name: o.HelmBinary,
-		Args: []string{"dependency", "build", "."},
+		Args: []string{"dependency", "build", ".", "--registry-config", o.RegistryConfigFile},
 	}
 	_, err = o.CommandRunner(c)
 	if err != nil {

--- a/pkg/cmd/helm/release/release.go
+++ b/pkg/cmd/helm/release/release.go
@@ -350,7 +350,7 @@ func (o *Options) oCIRegistry(repoURL, chartDir, name string) error {
 	c = &cmdrunner.Command{
 		Dir:  chartDir,
 		Name: o.HelmBinary,
-		Args: []string{"push", chartPackageName, repoURL, "--registry-config", o.RegistryConfigFile},
+		Args: []string{"push", chartPackageName, "oci://" + repoURL, "--registry-config", o.RegistryConfigFile},
 	}
 	_, err = o.CommandRunner(c)
 	if err != nil {

--- a/pkg/cmd/helm/release/release_test.go
+++ b/pkg/cmd/helm/release/release_test.go
@@ -249,7 +249,7 @@ func TestStepHelmReleaseWithOCIUsingUserName(t *testing.T) {
 			CLI: "helm registry login " + OCIRegistry + " --username " + o.RepositoryUsername + " --password " + o.RepositoryPassword,
 		},
 		fakerunner.FakeResult{
-			CLI: "helm push myapp-" + chartVersion + ".tgz " + OCIRegistry + " --registry-config " + o.RegistryConfigFile,
+			CLI: "helm push myapp-" + chartVersion + ".tgz oci://" + OCIRegistry + " --registry-config " + o.RegistryConfigFile,
 		},
 	)
 }
@@ -295,7 +295,7 @@ func TestStepHelmReleaseWithOCIUsingRegistryConfig(t *testing.T) {
 		},
 
 		fakerunner.FakeResult{
-			CLI: "helm push myapp-" + chartVersion + ".tgz " + OCIRegistry + " --registry-config " + o.RegistryConfigFile,
+			CLI: "helm push myapp-" + chartVersion + ".tgz " + "oci://" + OCIRegistry + " --registry-config " + o.RegistryConfigFile,
 		},
 	)
 }
@@ -338,7 +338,7 @@ func TestStepHelmReleaseWithOCINoOCILogin(t *testing.T) {
 		},
 
 		fakerunner.FakeResult{
-			CLI: "helm push myapp-" + chartVersion + ".tgz " + OCIRegistry + " --registry-config " + o.RegistryConfigFile,
+			CLI: "helm push myapp-" + chartVersion + ".tgz " + "oci://" + OCIRegistry + " --registry-config " + o.RegistryConfigFile,
 		})
 
 }
@@ -348,7 +348,7 @@ func setupReleaseOCI(t *testing.T) (*fakerunner.FakeRunner, string, string, *rel
 	helmBin := "helm"
 
 	ns := "jx2"
-	OCIRegistry := "oci://ociregistry"
+	OCIRegistry := "ociregistry"
 	chartVersion := "1.2.3"
 	devEnv := jxenv.CreateDefaultDevEnvironment(ns)
 	devEnv.Namespace = ns

--- a/pkg/cmd/helm/release/release_test.go
+++ b/pkg/cmd/helm/release/release_test.go
@@ -168,7 +168,7 @@ func TestStepHelmReleaseWithChartPages(t *testing.T) {
 			CLI: runner.OrderedCommands[0].Name + " " + strings.Join(runner.OrderedCommands[0].Args, " "),
 		},
 		fakerunner.FakeResult{
-			CLI: "helm repo add 0 file://../myapp-common",
+			CLI: "helm repo add 0 file://myapp-common",
 		},
 		fakerunner.FakeResult{
 			CLI: "git sparse-checkout set --no-cone jx-requirements.yml .jx/gitops/source-config.yaml",
@@ -228,6 +228,9 @@ func TestStepHelmReleaseWithOCIUsingUserName(t *testing.T) {
 			CLI: runner.OrderedCommands[0].Name + " " + strings.Join(runner.OrderedCommands[0].Args, " "),
 		},
 		fakerunner.FakeResult{
+			CLI: "helm repo add 0 file://myapp-common",
+		},
+		fakerunner.FakeResult{
 			CLI: "git sparse-checkout set --no-cone jx-requirements.yml .jx/gitops/source-config.yaml",
 		},
 		fakerunner.FakeResult{
@@ -273,6 +276,9 @@ func TestStepHelmReleaseWithOCIUsingRegistryConfig(t *testing.T) {
 			CLI: runner.OrderedCommands[0].Name + " " + strings.Join(runner.OrderedCommands[0].Args, " "),
 		},
 		fakerunner.FakeResult{
+			CLI: "helm repo add 0 file://myapp-common",
+		},
+		fakerunner.FakeResult{
 			CLI: "git sparse-checkout set --no-cone jx-requirements.yml .jx/gitops/source-config.yaml",
 		},
 		fakerunner.FakeResult{
@@ -311,6 +317,9 @@ func TestStepHelmReleaseWithOCINoOCILogin(t *testing.T) {
 		fakerunner.FakeResult{
 			// workaround for dynamically generated git clone destination folder
 			CLI: runner.OrderedCommands[0].Name + " " + strings.Join(runner.OrderedCommands[0].Args, " "),
+		},
+		fakerunner.FakeResult{
+			CLI: "helm repo add 0 file://myapp-common",
 		},
 		fakerunner.FakeResult{
 			CLI: "git sparse-checkout set --no-cone jx-requirements.yml .jx/gitops/source-config.yaml",

--- a/pkg/cmd/helm/release/release_test.go
+++ b/pkg/cmd/helm/release/release_test.go
@@ -168,6 +168,9 @@ func TestStepHelmReleaseWithChartPages(t *testing.T) {
 			CLI: runner.OrderedCommands[0].Name + " " + strings.Join(runner.OrderedCommands[0].Args, " "),
 		},
 		fakerunner.FakeResult{
+			CLI: "helm repo add 0 file://../myapp-common",
+		},
+		fakerunner.FakeResult{
 			CLI: "git sparse-checkout set --no-cone jx-requirements.yml .jx/gitops/source-config.yaml",
 		},
 		fakerunner.FakeResult{

--- a/pkg/cmd/helm/release/release_test.go
+++ b/pkg/cmd/helm/release/release_test.go
@@ -254,6 +254,7 @@ func TestStepHelmReleaseWithOCIUsingUserName(t *testing.T) {
 	)
 }
 
+//nolint:dupl
 func TestStepHelmReleaseWithOCIUsingRegistryConfig(t *testing.T) {
 	// force ChartOCI to true
 	// fake OCI registry vars
@@ -300,6 +301,7 @@ func TestStepHelmReleaseWithOCIUsingRegistryConfig(t *testing.T) {
 	)
 }
 
+//nolint:dupl
 func TestStepHelmReleaseWithOCINoOCILogin(t *testing.T) {
 	runner, OCIRegistry, chartVersion, o, err := setupReleaseOCI(t)
 	require.NoError(t, err, "failed to run the command")

--- a/pkg/cmd/helm/release/release_test.go
+++ b/pkg/cmd/helm/release/release_test.go
@@ -21,7 +21,7 @@ import (
 	"sigs.k8s.io/yaml"
 )
 
-const helmDependencyBuild = "helm dependency build ."
+const helmDependencyBuild = "helm dependency build . --registry-config "
 const helmLint = "helm lint"
 const helmPackage = "helm package ."
 
@@ -177,7 +177,7 @@ func TestStepHelmReleaseWithChartPages(t *testing.T) {
 			CLI: "git checkout",
 		},
 		fakerunner.FakeResult{
-			CLI: helmDependencyBuild,
+			CLI: helmDependencyBuild + o.RegistryConfigFile,
 		},
 		fakerunner.FakeResult{
 			CLI: helmLint,
@@ -234,7 +234,7 @@ func TestStepHelmReleaseWithOCIUsingUserName(t *testing.T) {
 			CLI: "git checkout",
 		},
 		fakerunner.FakeResult{
-			CLI: helmDependencyBuild,
+			CLI: helmDependencyBuild + o.RegistryConfigFile,
 		},
 		fakerunner.FakeResult{
 			CLI: helmLint,
@@ -279,7 +279,7 @@ func TestStepHelmReleaseWithOCIUsingRegistryConfig(t *testing.T) {
 			CLI: "git checkout",
 		},
 		fakerunner.FakeResult{
-			CLI: helmDependencyBuild,
+			CLI: helmDependencyBuild + o.RegistryConfigFile,
 		},
 		fakerunner.FakeResult{
 			CLI: helmLint,
@@ -319,7 +319,7 @@ func TestStepHelmReleaseWithOCINoOCILogin(t *testing.T) {
 			CLI: "git checkout",
 		},
 		fakerunner.FakeResult{
-			CLI: helmDependencyBuild,
+			CLI: helmDependencyBuild + o.RegistryConfigFile,
 		},
 		fakerunner.FakeResult{
 			CLI: helmLint,
@@ -339,7 +339,7 @@ func setupReleaseOCI(t *testing.T) (*fakerunner.FakeRunner, string, string, *rel
 	helmBin := "helm"
 
 	ns := "jx2"
-	OCIRegistry := "ociregistry"
+	OCIRegistry := "oci://ociregistry"
 	chartVersion := "1.2.3"
 	devEnv := jxenv.CreateDefaultDevEnvironment(ns)
 	devEnv.Namespace = ns

--- a/pkg/cmd/helm/release/testdata/charts/myapp/Chart.yaml
+++ b/pkg/cmd/helm/release/testdata/charts/myapp/Chart.yaml
@@ -5,5 +5,7 @@ version: 0.1.0-SNAPSHOT
 dependencies:
   - name: myapp-common
     version: 0.1.0-SNAPSHOT
-    repository: file://../myapp-common
- 
+    repository: file://myapp-common
+  - name: myapp-uncommon
+    version: 0.1.0-SNAPSHOT
+    repository: oci://myapp-uncommon

--- a/pkg/cmd/helm/release/testdata/charts/myapp/Chart.yaml
+++ b/pkg/cmd/helm/release/testdata/charts/myapp/Chart.yaml
@@ -1,5 +1,9 @@
-apiVersion: v1
+apiVersion: v2
 description: A Helm chart for Kubernetes
-icon: https://raw.githubusercontent.com/jenkins-x/jenkins-x-platform/d273e09/images/nodejs.png
 name: myapp
 version: 0.1.0-SNAPSHOT
+dependencies:
+  - name: myapp-common
+    version: 0.1.0-SNAPSHOT
+    repository: file://../myapp-common
+ 

--- a/pkg/cmd/plugin/upgrade/upgrade.go
+++ b/pkg/cmd/plugin/upgrade/upgrade.go
@@ -28,7 +28,7 @@ var (
 
 	cmdPluginsExample = templates.Examples(`
 		# upgrades your plugin binaries for gitops
-		%s plugins upgrade
+		%s plugin upgrade
 	`)
 )
 


### PR DESCRIPTION
This adds support for building & releasing helm charts that have dependencies on other helm charts. 
The use case is to make an umbrella helm chart containing a number of charts configured to work together as one deployable unit. 

I was only able to make this work by adding aws docker credential helper to the jx-gitops container. 

To add login credentials into a helmfile, you may pass environment variables like "REPO_NAME_PASSWORD", where REPO_NAME is the short name used to identify the repository in the helmfile.  
I guess it can be done, but to me it seems adding docker credential helpers makes it a lot easier.  