### PR TITLE
fix: field to distinguish repository groups

### DIFF
--- a/pkg/apis/gitops/v1alpha1/source_config_types.go
+++ b/pkg/apis/gitops/v1alpha1/source_config_types.go
@@ -147,8 +147,11 @@ type RepositoryGroup struct {
 	// Slack optional slack notification configuration
 	Slack *SlackNotify `json:"slack,omitempty"`
 
-	// Settings optional settinsg for repositories in this group
+	// Settings optional settings for repositories in this group
 	Settings *v4beta1.SettingsConfig `json:"settings,omitempty"`
+
+	// Name optional field to distinguish repository groups between for example different teams. Not used by jx gitops
+	Name string `json:"name,omitempty"`
 }
 
 // Repository the name of the repository to import and the optional scheduler


### PR DESCRIPTION
Useful to keep source-config.yml organised for example when having groups for different teams