### PR TITLE
fix: correct ingress details on custom namespaces

### DIFF
--- a/pkg/cmd/helmfile/resolve/resolve.go
+++ b/pkg/cmd/helmfile/resolve/resolve.go
@@ -286,18 +286,13 @@ func (o *Options) saveNamespaceJXValuesFile(helmfileDir, ns string) error {
 	subDomain := strings.ReplaceAll(requirements.Ingress.NamespaceSubDomain, "jx", ns)
 	requirements.Ingress.NamespaceSubDomain = subDomain
 
-	// TODO should we add a Namespace into the requirements.environments structures?
-	// lets assume either the key is the namespace or the namespace is "jx-${envKey}"
 	envKey := ""
 	for k := range requirements.Environments {
 		e := requirements.Environments[k]
-		if ns == e.Key {
-			envKey = ns
+		if (ns == e.Namespace) || (strings.TrimPrefix(ns, "jx-") == e.Key) {
+			envKey = e.Key
 			break
 		}
-	}
-	if envKey == "" {
-		envKey = strings.TrimPrefix(ns, "jx-")
 	}
 
 	// lets see if there is a custom ingress value for this namespace

--- a/pkg/cmd/helmfile/resolve/resolve_test.go
+++ b/pkg/cmd/helmfile/resolve/resolve_test.go
@@ -237,6 +237,16 @@ func TestStepHelmfileResolve(t *testing.T) {
 					domain:    "myprod.com",
 				},
 				{
+					namespace: "custom1",
+					subdomain: "testing.",
+					domain:    "mycustom.com",
+				},
+				{
+					namespace: "custom2",
+					subdomain: "testing.",
+					domain:    "defaultdomain.com",
+				},
+				{
 					namespace: "tekton-pipelines",
 					subdomain: "-tekton-pipelines.",
 					domain:    "defaultdomain.com",

--- a/pkg/cmd/helmfile/resolve/testdata/custom-env-ingress/expected-helmfile.yaml
+++ b/pkg/cmd/helmfile/resolve/testdata/custom-env-ingress/expected-helmfile.yaml
@@ -1,5 +1,7 @@
 filepath: ""
 helmfiles:
+- path: helmfiles/custom1/helmfile.yaml
+- path: helmfiles/custom2/helmfile.yaml
 - path: helmfiles/foo/helmfile.yaml
 - path: helmfiles/jx/helmfile.yaml
 - path: helmfiles/jx-production/helmfile.yaml

--- a/pkg/cmd/helmfile/resolve/testdata/custom-env-ingress/helmfile.yaml
+++ b/pkg/cmd/helmfile/resolve/testdata/custom-env-ingress/helmfile.yaml
@@ -12,6 +12,10 @@ releases:
     namespace: jx-staging
   - chart: doesnotexist/myapp
     namespace: jx-production
+  - chart: doesnotexist/myapp
+    namespace: custom1
+  - chart: doesnotexist/myapp
+    namespace: custom2
   - chart: bitnami/external-dns
     namespace: foo
   # test using a local repo prefix and URL

--- a/pkg/cmd/helmfile/resolve/testdata/custom-env-ingress/jx-requirements.yml
+++ b/pkg/cmd/helmfile/resolve/testdata/custom-env-ingress/jx-requirements.yml
@@ -19,6 +19,15 @@ spec:
     ingress:
       domain: "myprod.com"
       namespaceSubDomain: "."
+  - key: custom-namespace1
+    ingress:
+      domain: "mycustom.com"
+      namespaceSubDomain: "testing."
+    namespace: custom1
+  - key: custom-namespace2
+    ingress:
+      namespaceSubDomain: "testing."
+    namespace: custom2
   ingress:
     domain: "defaultdomain.com"
     externalDNS: false


### PR DESCRIPTION
Where a namespace is specified for an environment,
custom ingress settings (ingress.domain & ingress.nameSpaceSubDomain)
should be populated in jx-values for the namespaces
fixes https://github.com/jenkins-x/jx/issues/8514