### PR TITLE
small fixes for helmfile handling

### DIFF
--- a/pkg/cmd/helmfile/report/report.go
+++ b/pkg/cmd/helmfile/report/report.go
@@ -169,7 +169,7 @@ func (o *Options) Run() error {
 				chartMap[nc.Namespace] = nsMap
 			}
 			for _, ri := range nc.Releases {
-				nsMap[ri.Name] = ri
+				nsMap[ri.ReleaseName] = ri
 			}
 		}
 		o.PreviousNamespaceCharts = chartMap
@@ -320,23 +320,13 @@ func (o *Options) createReleaseInfo(helmState *state.HelmState, ns string, rel *
 	return answer, nil
 }
 
-func localName(chartName string) string {
-	paths := strings.SplitN(chartName, "/", 2)
-	if len(paths) == 2 {
-		return paths[1]
-	}
-	return chartName
-}
-
 func (o *Options) enrichChartMetadata(i *releasereport.ReleaseInfo, repo *state.RepositorySpec, rel *state.ReleaseSpec, ns string) error {
 	if repo.OCI {
 		return nil
 	}
 	// lets see if we can find the previous data in the previous release
-	localChartName := localName(rel.Chart)
-
 	if nsMap, found := o.PreviousNamespaceCharts[ns]; found {
-		ch := nsMap[localChartName]
+		ch := nsMap[rel.Name]
 		if ch != nil {
 			if ch.Version == rel.Version {
 				*i = *ch

--- a/pkg/cmd/helmfile/status/status.go
+++ b/pkg/cmd/helmfile/status/status.go
@@ -146,7 +146,7 @@ func (o *Options) Run() error {
 		gitServer := stringhelpers.FirstNotEmptyString(c.GitServer, giturl.GitHubURL)
 		for _, nsr := range o.NamespaceReleases {
 			for _, release := range nsr.Releases {
-				if !(o.DeployCutoff.IsZero() || release.LastDeployed == nil || o.DeployCutoff.Before(release.LastDeployed.Time)) {
+				if release.LastDeployed == nil || !(o.DeployCutoff.IsZero() || o.DeployCutoff.Before(release.LastDeployed.Time)) {
 					continue
 				}
 


### PR DESCRIPTION
The fix to report solves the problem that lastDeployTime is updated on every execution of `jx gitops helmfile report` if you have several releases in the same namespace of the same chart, but different versions. The bug mainly causes problems with merge conflicts.

The change to status means that we avoid creating deployment in github for releases without lastDeployTime. Since this also means that version is missing it essentially means that a warning log message is avoided.