### PR TITLE
fix: upgrade kubectl

### DIFF
--- a/pkg/plugins/versions.go
+++ b/pkg/plugins/versions.go
@@ -30,8 +30,8 @@ const (
 	// KptVersion the default version of kpt to use
 	KptVersion = "1.0.0-beta.17"
 
-	// KubectlVersion the default version of kpt to use
-	KubectlVersion = "1.21.0"
+	// KubectlVersion the default version of kubectl to use
+	KubectlVersion = "1.24.9"
 
 	// KappVersion the default version of kapp to use
 	KappVersion = "0.35.1-cmfork"


### PR DESCRIPTION
Especially to get rid of error in jx boot job

error: error retrieving RESTMappings to prune: invalid resource batch/v1beta1, Kind=CronJob, Namespaced=true: no matches for kind "CronJob" in version "batch/v1beta1"

Related to jenkins-x/jx#8454