### PR TITLE
fix: issue with duplicate helmfiles being returned

### DIFF
--- a/pkg/cmd/helmfile/resolve/testdata/remote-chart/expected-foo-helmfile.yaml
+++ b/pkg/cmd/helmfile/resolve/testdata/remote-chart/expected-foo-helmfile.yaml
@@ -5,7 +5,6 @@ environments:
     - jx-values.yaml
 namespace: foo
 repositories:
-- {}
 - name: bitnami
   url: https://charts.bitnami.com/bitnami
 releases:

--- a/pkg/helmfiles/helpers.go
+++ b/pkg/helmfiles/helpers.go
@@ -1,13 +1,11 @@
 package helmfiles
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 
 	"github.com/helmfile/helmfile/pkg/state"
-	"github.com/jenkins-x/jx-helpers/v3/pkg/files"
 	"github.com/jenkins-x/jx-helpers/v3/pkg/yaml2s"
 	"github.com/pkg/errors"
 )
@@ -45,7 +43,6 @@ func GatherHelmfiles(helmfile, dir string) ([]Helmfile, error) {
 	helmfiles := []Helmfile{
 		{helmfile, relativePath},
 	}
-	parentHelmfileDir := filepath.Dir(helmfile)
 
 	for _, nested := range helmState.Helmfiles {
 		// lets ignore remote helmfiles
@@ -63,19 +60,6 @@ func GatherHelmfiles(helmfile, dir string) ([]Helmfile, error) {
 			return nil, errors.Wrapf(err, "failed to get nested helmnfiles %s in %s", nested.Path, dir)
 		}
 		helmfiles = append(helmfiles, nestedHelmfile...)
-
-		nestedHelmfileDepth := len(strings.Split(filepath.Dir(nested.Path), pathSeparator))
-		relativePath := strings.Repeat("../", parentHelmfileDepth+nestedHelmfileDepth)
-
-		fileLocation := filepath.Join(parentHelmfileDir, nested.Path)
-		exists, err := files.FileExists(fileLocation)
-		if err != nil {
-			return nil, errors.Wrapf(err, "failed to check for nested helmfile %s", fileLocation)
-		}
-		if !exists {
-			return nil, fmt.Errorf("failed to find nested helmfile %s", fileLocation)
-		}
-		helmfiles = append(helmfiles, Helmfile{fileLocation, relativePath})
 	}
 	return helmfiles, nil
 }

--- a/pkg/helmfiles/helpers_test.go
+++ b/pkg/helmfiles/helpers_test.go
@@ -1,0 +1,37 @@
+package helmfiles_test
+
+import (
+	"testing"
+
+	"github.com/jenkins-x-plugins/jx-gitops/pkg/helmfiles"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGatherHelmfiles(t *testing.T) {
+	expected := []helmfiles.Helmfile{
+		{
+			Filepath:           "helpers_test_data/helmfile.yaml",
+			RelativePathToRoot: "",
+		},
+		{
+			Filepath:           "helpers_test_data/helmfiles/jx/helmfile.yaml",
+			RelativePathToRoot: "../../",
+		},
+		{
+			Filepath:           "helpers_test_data/helmfiles/jx/helmfiles/nested/helmfile.yaml",
+			RelativePathToRoot: "../../../../",
+		},
+		{
+			Filepath:           "helpers_test_data/helmfiles/nginx/helmfile.yaml",
+			RelativePathToRoot: "../../",
+		},
+		{
+			Filepath:           "helpers_test_data/helmfiles/cert-manager/helmfile.yaml",
+			RelativePathToRoot: "../../",
+		},
+	}
+
+	actual, err := helmfiles.GatherHelmfiles("helmfile.yaml", "helpers_test_data")
+	assert.NoError(t, err)
+	assert.Equal(t, expected, actual)
+}

--- a/pkg/helmfiles/helpers_test_data/helmfile.yaml
+++ b/pkg/helmfiles/helpers_test_data/helmfile.yaml
@@ -1,0 +1,7 @@
+filepath: ""
+helmfiles:
+- path: helmfiles/jx/helmfile.yaml
+- path: helmfiles/nginx/helmfile.yaml
+- path: helmfiles/cert-manager/helmfile.yaml
+templates: {}
+renderedvalues: {}

--- a/pkg/helmfiles/helpers_test_data/helmfiles/cert-manager/helmfile.yaml
+++ b/pkg/helmfiles/helpers_test_data/helmfiles/cert-manager/helmfile.yaml
@@ -1,0 +1,4 @@
+filepath: ""
+namespace: cert-manager
+templates: {}
+renderedvalues: {}

--- a/pkg/helmfiles/helpers_test_data/helmfiles/jx/helmfile.yaml
+++ b/pkg/helmfiles/helpers_test_data/helmfiles/jx/helmfile.yaml
@@ -1,0 +1,6 @@
+filepath: ""
+namespace: jx
+helmfiles:
+  - path: helmfiles/nested/helmfile.yaml
+templates: {}
+renderedvalues: {}

--- a/pkg/helmfiles/helpers_test_data/helmfiles/jx/helmfiles/nested/helmfile.yaml
+++ b/pkg/helmfiles/helpers_test_data/helmfiles/jx/helmfiles/nested/helmfile.yaml
@@ -1,0 +1,4 @@
+filepath: ""
+namespace: nested
+templates: {}
+renderedvalues: {}

--- a/pkg/helmfiles/helpers_test_data/helmfiles/nginx/helmfile.yaml
+++ b/pkg/helmfiles/helpers_test_data/helmfiles/nginx/helmfile.yaml
@@ -1,0 +1,4 @@
+filepath: ""
+namespace: nginx
+templates: {}
+renderedvalues: {}


### PR DESCRIPTION
Noticed issues with `jx gitops helmfile report` where namespaces were being reported twice. Seems that `GatherHelmfiles()` is both recursively finding a nested helmfile and appending it, but then also appending the same file by calculating it's location.

Removing the calculation resolves the issue but highlighted another issue in `jx gitops helmfile resolve` where if both a "jx3" and "jenkins-x" repository were found then only one was removed. This has also been fixed.

