### PR TITLE
chore: upgrade kpt

### DIFF
--- a/pkg/plugins/versions.go
+++ b/pkg/plugins/versions.go
@@ -28,7 +28,7 @@ const (
 	HelmfileVersion = "0.146.0"
 
 	// KptVersion the default version of kpt to use
-	KptVersion = "1.0.0-beta.17"
+	KptVersion = "1.0.0-beta.45"
 
 	// KubectlVersion the default version of kubectl to use
 	KubectlVersion = "1.25.13"


### PR DESCRIPTION
In particular to get the k8s libraries upgraded from 0.24 to 0.26