### PR TITLE
chore: upgrade helmfile to 0.149.0

### DIFF
--- a/pkg/plugins/versions.go
+++ b/pkg/plugins/versions.go
@@ -25,7 +25,7 @@ const (
 	HelmVersion = "3.13.3"
 
 	// HelmfileVersion the default version of helmfile to use
-	HelmfileVersion = "0.146.0"
+	HelmfileVersion = "0.149.0"
 
 	// KptVersion the default version of kpt to use
 	KptVersion = "1.0.0-beta.45"


### PR DESCRIPTION
[v0.149.0](https://github.com/helmfile/helmfile/releases/tag/v0.149.0) is the latest version which avoids the backwards-incompatible logic in https://github.com/helmfile/helmfile/pull/592, but contains the fix in https://github.com/helmfile/helmfile/pull/499 which unblocks me from using `export HELMFILE_USE_SELECTORS = true` in my bootjob Makefile.