### PR TITLE
feat(comment): allow to choose between 3 comment strategies

### DIFF
--- a/pkg/cmd/pr/comment/comment.go
+++ b/pkg/cmd/pr/comment/comment.go
@@ -147,7 +147,7 @@ func (o *Options) createIfNotExists(ctx context.Context, pr *scm.PullRequest) er
 
 	for i := range existingComments {
 		comment := existingComments[i]
-		if comment.Body == o.Comment {
+		if o.ScmClient.Username == comment.Author.Login && comment.Body == o.Comment {
 			log.Logger().Infof("Similar comment already exists on pull request #%d on repository %s", o.Number, o.FullRepositoryName)
 			return nil
 		}
@@ -165,7 +165,7 @@ func (o *Options) deleteAndCreate(ctx context.Context, pr *scm.PullRequest) erro
 	similarComments := make([]*scm.Comment, 0)
 	for i := range existingComments {
 		comment := existingComments[i]
-		if comment.Body == o.Comment {
+		if o.ScmClient.Username == comment.Author.Login && comment.Body == o.Comment {
 			similarComments = append(similarComments, comment)
 		}
 	}

--- a/pkg/cmd/pr/comment/comment_test.go
+++ b/pkg/cmd/pr/comment/comment_test.go
@@ -12,39 +12,77 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestPullRequestComment(t *testing.T) {
+func TestPullRequestCommentStrategies(t *testing.T) {
+	scenarios := []struct {
+		name                 string
+		strategy             string
+		newCommentText       string
+		existingCommentsText []string
+		expectedCommentCount int
+	}{
+		{name: "CreateCommentStrategy-Existing", strategy: comment.CreateCommentStrategy, newCommentText: "comment for CreateCommentStrategy", existingCommentsText: []string{"comment for CreateCommentStrategy"}, expectedCommentCount: 2},
+		{name: "CreateCommentStrategy-NotExisting", strategy: comment.CreateCommentStrategy, newCommentText: "new-comment for CreateCommentStrategy", existingCommentsText: []string{"comment for CreateCommentStrategy"}, expectedCommentCount: 2},
+		{name: "CreateIfNotExistsCommentStrategy-Existing", strategy: comment.CreateIfNotExistsCommentStrategy, newCommentText: "existing-comment for CreateIfNotExistsCommentStrategy", existingCommentsText: []string{"existing-comment for CreateIfNotExistsCommentStrategy"}, expectedCommentCount: 1},
+		{name: "CreateIfNotExistsCommentStrategy-NotExisting", strategy: comment.CreateIfNotExistsCommentStrategy, newCommentText: "new-comment for CreateIfNotExistsCommentStrategy", existingCommentsText: []string{"existing-comment for CreateIfNotExistsCommentStrategy"}, expectedCommentCount: 2},
+		{name: "DeleteAndCreateCommentStrategy-Existing", strategy: comment.DeleteAndCreateCommentStrategy, newCommentText: "comment for DeleteAndCreateCommentStrategy", existingCommentsText: []string{"comment for DeleteAndCreateCommentStrategy", "existing-comment for DeleteAndCreateCommentStrategy"}, expectedCommentCount: 2},
+		{name: "DeleteAndCreateCommentStrategy-NotExisting", strategy: comment.DeleteAndCreateCommentStrategy, newCommentText: "comment for DeleteAndCreateCommentStrategy", existingCommentsText: []string{"existing-comment for DeleteAndCreateCommentStrategy"}, expectedCommentCount: 2},
+	}
+
+	for _, scenario := range scenarios {
+		t.Run(scenario.name, func(t *testing.T) {
+			o := setupOptionsAndData(scenario.strategy, scenario.newCommentText, scenario.existingCommentsText)
+			testCommentStrategy(t, o, scenario.expectedCommentCount)
+		})
+	}
+}
+
+func setupOptionsAndData(strategy string, newCommentText string, existingCommentsText []string) *comment.Options {
 	_, o := comment.NewCmdPullRequestComment()
 
 	prNumber := 123
 	repo := "myorg/myrepo"
 	prBranch := "my-pr-branch-name"
-	expectedComment := "hello from a pipeline"
 
 	runner := &fakerunner.FakeRunner{}
 	o.CommandRunner = runner.Run
 	o.SourceURL = "https://github.com/" + repo
 	o.Number = prNumber
 	o.Branch = prBranch
-	o.Comment = expectedComment
+	o.Comment = newCommentText
+	o.Strategy = strategy
 
 	scmClient, fakeData := fake.NewDefault()
 	o.ScmClient = scmClient
+
 	fakeData.PullRequests[prNumber] = &scm.PullRequest{
 		Number: prNumber,
-		Title:  "my awesome pull request",
-		Body:   "some text",
-		Source: prBranch,
+		Title:  "my-pr",
+		Body:   "body",
 	}
 
+	// Add existing comments to the pull request
+	for _, existingCommentText := range existingCommentsText {
+		fakeData.PullRequestComments[prNumber] = append(fakeData.PullRequestComments[prNumber], &scm.Comment{
+			Body: existingCommentText,
+		})
+	}
+
+	return o
+}
+
+func testCommentStrategy(t *testing.T, o *comment.Options, expectedCommentCount int) {
 	err := o.Run()
 	require.NoError(t, err, "failed to run ")
 
 	ctx := context.Background()
-	comments, _, err := o.ScmClient.PullRequests.ListComments(ctx, repo, prNumber, scm.ListOptions{})
+	comments, _, err := o.ScmClient.PullRequests.ListComments(ctx, o.Repository, o.Number, scm.ListOptions{})
 	require.NoError(t, err, "failed to list comments")
 	require.NotEmpty(t, comments, "should have some comments")
 
 	lastComment := comments[len(comments)-1]
-	assert.Equal(t, expectedComment, lastComment.Body, "lastComment.Body")
-	t.Logf("pull request #%d, has comment: %s\n", prNumber, lastComment.Body)
+
+	assert.Equal(t, expectedCommentCount, len(comments), "expectedCommentCount")
+	assert.Equal(t, o.Comment, lastComment.Body, "lastComment.Body")
+
+	t.Logf("pull request #%d, has comments: %s\n", o.Number, lastComment.Body)
 }

--- a/pkg/cmd/pr/comment/comment_test.go
+++ b/pkg/cmd/pr/comment/comment_test.go
@@ -97,13 +97,13 @@ func TestPullRequestCommentStrategies(t *testing.T) {
 
 	for _, scenario := range scenarios {
 		t.Run(scenario.name, func(t *testing.T) {
-			o := setupOptionsAndData(scenario.strategy, scenario.newCommentText, scenario.existingCommentsText, scenario.author)
+			o := setupOptionsAndData(scenario.strategy, scenario.author, scenario.newCommentText, scenario.existingCommentsText)
 			testCommentStrategy(t, o, scenario.expectedCommentCount)
 		})
 	}
 }
 
-func setupOptionsAndData(strategy string, newCommentText string, existingCommentsText []string, author string) *comment.Options {
+func setupOptionsAndData(strategy, author, newCommentText string, existingCommentsText []string) *comment.Options {
 	_, o := comment.NewCmdPullRequestComment()
 
 	prNumber := 123


### PR DESCRIPTION
This PR allows to choose between 3 different comment strategies:
- create (to always create a comment, this is the default strategy and the one used before)
- create-if-not-exists (to create a comment only if its content doesn't already exist on the associated PR)
- delete-and-create (to delete comment(s) if the content is similar and create the comment again

The check / deletion is only done to comment with similar Author Login :ok_hand:  

Examples:
Create Strategy:
```
jx-gitops pr comment -s create -c ':star:TEST COMMENT:star:'
commented on pull request #22 on repository xxx/test-comment
```
Create If Not Exists Strategy
```
jx-gitops pr comment -s create-if-not-exists -c ':star:TEST COMMENT:star:'
Similar comment already exists on pull request #22 on repository xxx/test-comment
```
Delete and Create Strategy
```
jx-gitops pr comment -s delete-and-create -c ':star:TEST COMMENT:star:'
deleted comment with ID 12345 on pull request #22 on repository xxx/test-comment
commented on pull request #22 on repository xxx/test-comment
```

No defined Strategies (using the default one create)
```
jx-gitops pr comment -c ':star:TEST COMMENT:star:'
commented on pull request #22 on repository xxx/test-comment
```

#############


Tests are passing locally

```
go test -v ./pkg/cmd/pr/comment
=== RUN   TestPullRequestCommentStrategies
=== RUN   TestPullRequestCommentStrategies/CreateCommentStrategy-Existing-DifferentUser
commented on pull request #123 on repository myorg/myrepo
    comment_test.go:162: pull request #123, has comments: comment for CreateCommentStrategy
=== RUN   TestPullRequestCommentStrategies/CreateIfNotExistsCommentStrategy-Existing-DifferentUser
commented on pull request #123 on repository myorg/myrepo
    comment_test.go:162: pull request #123, has comments: comment for CreateIfNotExistsCommentStrategy
=== RUN   TestPullRequestCommentStrategies/DeleteAndCreateCommentStrategy-Existing-DifferentUser
commented on pull request #123 on repository myorg/myrepo
    comment_test.go:162: pull request #123, has comments: comment for DeleteAndCreateCommentStrategy
=== RUN   TestPullRequestCommentStrategies/CreateCommentStrategy-Existing-SimilarUser
commented on pull request #123 on repository myorg/myrepo
    comment_test.go:162: pull request #123, has comments: comment for CreateCommentStrategy
=== RUN   TestPullRequestCommentStrategies/CreateCommentStrategy-NotExisting-SimilarUser
commented on pull request #123 on repository myorg/myrepo
    comment_test.go:162: pull request #123, has comments: new-comment for CreateCommentStrategy
=== RUN   TestPullRequestCommentStrategies/CreateIfNotExistsCommentStrategy-Existing-SimilarUser
Similar comment already exists on pull request #123 on repository myorg/myrepo
    comment_test.go:162: pull request #123, has comments: existing-comment for CreateIfNotExistsCommentStrategy
=== RUN   TestPullRequestCommentStrategies/CreateIfNotExistsCommentStrategy-NotExisting-SimilarUser
commented on pull request #123 on repository myorg/myrepo
    comment_test.go:162: pull request #123, has comments: new-comment for CreateIfNotExistsCommentStrategy
=== RUN   TestPullRequestCommentStrategies/DeleteAndCreateCommentStrategy-Existing-SimilarUser
deleted comment with ID 0 on pull request #123 on repository myorg/myrepo
commented on pull request #123 on repository myorg/myrepo
    comment_test.go:162: pull request #123, has comments: comment for DeleteAndCreateCommentStrategy
=== RUN   TestPullRequestCommentStrategies/DeleteAndCreateCommentStrategy-NotExisting-SimilarUser
commented on pull request #123 on repository myorg/myrepo
    comment_test.go:162: pull request #123, has comments: comment for DeleteAndCreateCommentStrategy
--- PASS: TestPullRequestCommentStrategies (0.00s)
    --- PASS: TestPullRequestCommentStrategies/CreateCommentStrategy-Existing-DifferentUser (0.00s)
    --- PASS: TestPullRequestCommentStrategies/CreateIfNotExistsCommentStrategy-Existing-DifferentUser (0.00s)
    --- PASS: TestPullRequestCommentStrategies/DeleteAndCreateCommentStrategy-Existing-DifferentUser (0.00s)
    --- PASS: TestPullRequestCommentStrategies/CreateCommentStrategy-Existing-SimilarUser (0.00s)
    --- PASS: TestPullRequestCommentStrategies/CreateCommentStrategy-NotExisting-SimilarUser (0.00s)
    --- PASS: TestPullRequestCommentStrategies/CreateIfNotExistsCommentStrategy-Existing-SimilarUser (0.00s)
    --- PASS: TestPullRequestCommentStrategies/CreateIfNotExistsCommentStrategy-NotExisting-SimilarUser (0.00s)
    --- PASS: TestPullRequestCommentStrategies/DeleteAndCreateCommentStrategy-Existing-SimilarUser (0.00s)
    --- PASS: TestPullRequestCommentStrategies/DeleteAndCreateCommentStrategy-NotExisting-SimilarUser (0.00s)
PASS
ok      github.com/jenkins-x-plugins/jx-gitops/pkg/cmd/pr/comment       0.030s
```