### PR TITLE
Speed up helmfile report

### DIFF
--- a/pkg/apis/gitops/v1alpha1/kpt_strategy_types.go
+++ b/pkg/apis/gitops/v1alpha1/kpt_strategy_types.go
@@ -25,7 +25,7 @@ type KptStrategies struct {
 type KptStrategyConfig struct {
 	// RelativePath the relative path to the folder the strategy should apply to
 	RelativePath string `json:"relativePath" validate:"nonzero"`
-	// Strategy is the merge strategy kpt will use see https://googlecontainertools.github.io/kpt/reference/pkg/update/#flags
+	// Strategy is the merge strategy kpt will use see https://kpt.dev/reference/cli/pkg/update/?id=flags
 	Strategy string `json:"strategy" validate:"nonzero"`
 }
 


### PR DESCRIPTION
jx gitops helmfile report can be quite slow. This should improve the performance quite a bit.

This is done by checking only once for each repository whether it is added and at the same time also load the index file. The chart metadata is then fetched from the index file directly instead of executing `helm show chart`.