### PR TITLE
ci: update release-binary golang version to 1.22.1

### DIFF
--- a/.lighthouse/jenkins-x/release.yaml
+++ b/.lighthouse/jenkins-x/release.yaml
@@ -28,7 +28,12 @@ spec:
         - name: jx-variables
           resources: {}
         - name: release-binary
+          image: golang:1.22.1
           resources: {}
+          script: |
+            #!/bin/bash
+            source .jx/variables.sh
+            make release
         - image: uses:jenkins-x/jx3-pipeline-catalog/tasks/build-scan-push/build-scan-push.yaml@versionStream
           name: build-container
         - image: uses:jenkins-x/jx3-pipeline-catalog/tasks/build-scan-push/build-scan-push.yaml@versionStream


### PR DESCRIPTION
related to: https://github.com/jenkins-x-plugins/jx-gitops/pull/956

needed to make release pipeline pass