### PR TITLE
fix: reduce number of binaries to build

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -29,8 +29,10 @@ builds:
   # Defaults are 386 and amd64.
   goarch:
   - amd64
-  - arm
   - arm64
+  ignore:
+  - goos: windows
+    goarch: arm64
 archives:
 - name_template: "jx-gitops-{{ .Os }}-{{ .Arch }}"
   format_overrides:


### PR DESCRIPTION
Nobody is downloading any arm or windows/arm64 binaries, so to save resources we stop building those

<img width="520" alt="Download statistics for jx-gitops" src="https://github.com/user-attachments/assets/a0a2b2f8-c170-4b53-82ba-2eec688f00ce">

Statistics where fetched using https://qii404.me/github-release-statistics/

The one download of most resources aught to be down to something in the build process.