### PR TITLE
feat: attempt partial clone of cluster repo when loading requirements

### DIFF
--- a/pkg/cmd/helm/release/release_test.go
+++ b/pkg/cmd/helm/release/release_test.go
@@ -168,6 +168,12 @@ func TestStepHelmReleaseWithChartPages(t *testing.T) {
 			CLI: runner.OrderedCommands[0].Name + " " + strings.Join(runner.OrderedCommands[0].Args, " "),
 		},
 		fakerunner.FakeResult{
+			CLI: "git sparse-checkout set --no-cone .jx/gitops/source-config.yaml",
+		},
+		fakerunner.FakeResult{
+			CLI: "git checkout",
+		},
+		fakerunner.FakeResult{
 			CLI: helmDependencyBuild,
 		},
 		fakerunner.FakeResult{
@@ -219,6 +225,12 @@ func TestStepHelmReleaseWithOCIUsingUserName(t *testing.T) {
 			CLI: runner.OrderedCommands[0].Name + " " + strings.Join(runner.OrderedCommands[0].Args, " "),
 		},
 		fakerunner.FakeResult{
+			CLI: "git sparse-checkout set --no-cone .jx/gitops/source-config.yaml",
+		},
+		fakerunner.FakeResult{
+			CLI: "git checkout",
+		},
+		fakerunner.FakeResult{
 			CLI: helmDependencyBuild,
 		},
 		fakerunner.FakeResult{
@@ -258,6 +270,12 @@ func TestStepHelmReleaseWithOCIUsingRegistryConfig(t *testing.T) {
 			CLI: runner.OrderedCommands[0].Name + " " + strings.Join(runner.OrderedCommands[0].Args, " "),
 		},
 		fakerunner.FakeResult{
+			CLI: "git sparse-checkout set --no-cone .jx/gitops/source-config.yaml",
+		},
+		fakerunner.FakeResult{
+			CLI: "git checkout",
+		},
+		fakerunner.FakeResult{
 			CLI: helmDependencyBuild,
 		},
 		fakerunner.FakeResult{
@@ -290,6 +308,12 @@ func TestStepHelmReleaseWithOCINoOCILogin(t *testing.T) {
 		fakerunner.FakeResult{
 			// workaround for dynamically generated git clone destination folder
 			CLI: runner.OrderedCommands[0].Name + " " + strings.Join(runner.OrderedCommands[0].Args, " "),
+		},
+		fakerunner.FakeResult{
+			CLI: "git sparse-checkout set --no-cone .jx/gitops/source-config.yaml",
+		},
+		fakerunner.FakeResult{
+			CLI: "git checkout",
 		},
 		fakerunner.FakeResult{
 			CLI: helmDependencyBuild,

--- a/pkg/sourceconfigs/helpers.go
+++ b/pkg/sourceconfigs/helpers.go
@@ -17,11 +17,12 @@ import (
 )
 
 var info = termcolor.ColorInfo
+var SourceConfigFile = filepath.Join(".jx", "gitops", v1alpha1.SourceConfigFileName)
 
 // LoadSourceConfig loads the source config and optionally adds the default vlaues
 func LoadSourceConfig(dir string, applyDefaults bool) (*v1alpha1.SourceConfig, error) {
 	config := &v1alpha1.SourceConfig{}
-	path := filepath.Join(dir, ".jx", "gitops", v1alpha1.SourceConfigFileName)
+	path := filepath.Join(dir, SourceConfigFile)
 
 	exists, err := files.FileExists(path)
 	if err != nil {

--- a/pkg/variablefinders/requirements.go
+++ b/pkg/variablefinders/requirements.go
@@ -95,7 +95,7 @@ func GetSettings(g gitclient.Interface, jxClient jxc.Interface, ns, dir, owner, 
 			return nil, "", errors.New("failed to find a dev environment source url on development environment resource")
 		}
 	}
-	clusterDir, err := requirements.CloneClusterRepo(g, gitURL)
+	clusterDir, err := requirements.PartialCloneClusterRepo(g, gitURL, true, sourceconfigs.SourceConfigFile)
 	if err != nil {
 		return nil, "", err
 	}

--- a/pkg/variablefinders/requirements_test.go
+++ b/pkg/variablefinders/requirements_test.go
@@ -72,7 +72,7 @@ func TestFindRequirements(t *testing.T) {
 					devGitPath := filepath.Join(dir, "dev-env")
 					destDir := command.Dir
 					if len(command.Args) > 2 {
-						destDir = command.Args[2]
+						destDir = command.Args[len(command.Args)-1]
 					}
 					err := files.CopyDirOverwrite(devGitPath, destDir)
 					if err != nil {


### PR DESCRIPTION
Use `PartialCloneClusterRepo` (from following addition to `jx-helpers` - https://github.com/jenkins-x/jx-helpers/pull/420) to attempt sparse and partial clone of the upstream cluster repository, as only the `.jx/gitops/source-config.yaml` file is required when finding requirements with `variablefinders`.

This change impacts the speed of `jx gitops helm release` and `jx gitops variables` commands when the upstream git provider supports `git-sparse-checkout`, in addition to the `--filter=blob:none` and `--depth=1` flags. Falls back to a full clone if neither are supported.

Picking a real example that is used for the following `jx-variables` pipeline task step - https://github.com/jenkins-x/jx3-pipeline-catalog/blob/b14ab0afd073539a25e5f2cee342f1e99537b46a/tasks/csharp/pullrequest.yaml#L27-L36:

Before (step duration = 1m 16s):

![Screenshot_20241016_123448-1](https://github.com/user-attachments/assets/42444eae-e73a-4736-86da-a6d723d67b8c)

After (step duration = 8s):

![sparse-clone](https://github.com/user-attachments/assets/bfa97287-87f8-4092-92ca-eda5ffcafa35)


