### PR TITLE
chore: add --no-push flag; set logic for mirror to git push

### DIFF
--- a/pkg/cmd/helm/mirror/mirror.go
+++ b/pkg/cmd/helm/mirror/mirror.go
@@ -32,7 +32,7 @@ var (
 	info = termcolor.ColorInfo
 
 	cmdLong = templates.LongDesc(`
-		Escapes any {{ or }} characters in the YAML files so they can be included in a helm chart
+		Mirrors a set of remote Helm repositories specified locally in charts/repositories.yml to a remote git repository
 `)
 
 	cmdExample = templates.Examples(`

--- a/pkg/cmd/helm/mirror/mirror.go
+++ b/pkg/cmd/helm/mirror/mirror.go
@@ -36,8 +36,11 @@ var (
 `)
 
 	cmdExample = templates.Examples(`
-		# escapes any yaml files so they can be included in a helm chart 
-		%s helm escape --dir myyaml
+	# Mirror all Helm repositories defined in charts/repositories.yml to a default github pages branch
+	%s mirror --url=https://github.com/example/charts.git --no-push=false
+	
+	# Run the mirror command, ignoring unused repositories
+	%s mirror --url=https://github.com/example/charts.git --no-push=false --exclude=bitnami
 	`)
 )
 
@@ -61,7 +64,7 @@ func NewCmdMirror() (*cobra.Command, *Options) {
 
 	cmd := &cobra.Command{
 		Use:     "mirror",
-		Short:   "Creates a helm mirror ",
+		Short:   "Mirror a helm repository",
 		Long:    cmdLong,
 		Example: fmt.Sprintf(cmdExample, rootcmd.BinaryName),
 		Run: func(_ *cobra.Command, _ []string) {


### PR DESCRIPTION
`jx gitops helm mirror` does not push to the destination repository, as expected and specified in the documentation.

THis PR creates a `--no-push` flag, which defaults to `true`. This preserves the current behaviour, preventing this becoming a breaking change. This also fixes incorrect documentation.