### PR TITLE
chore: change deprecated goreleaser config

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,3 +1,4 @@
+version: 2
 env:
 - GO111MODULE=on
 - CGO_ENABLED=0
@@ -48,7 +49,7 @@ checksum:
   algorithm: sha256
 changelog:
   # set it to true if you wish to skip the changelog generation
-  skip: true
+  disable: true
 release:
   # If set to true, will not auto-publish the release.
   # Default is false.


### PR DESCRIPTION
The pipeline's `goreleaser` is now on v2 #https://github.com/jenkins-x/jx3-pipeline-catalog/pull/1553, causing release pipelines to fail.

Changes to `.goreleaser.yaml` fix this:
- Change a deprecated changelog setting (https://goreleaser.com/deprecations/#changelogskip)
- Explicitly set `version: 2`

Tested locally with:
```
$ goreleaser --version
GitVersion:    2.4.4
GoVersion:     go1.23.2

Before:
```
$ goreleaser check
  ⨯ command failed                                   error=yaml: unmarshal errors:
  line 52: field skip not found in type config.Changelog
```

After:
```
$ goreleaser check
  • checking                                 path=.goreleaser.yml
  • 1 configuration file(s) validated
  • thanks for using goreleaser!
```

