### PR TITLE
fix: Check out jx-requirements.yml from cluster repo upon sparse checkout

### DIFF
--- a/pkg/cmd/helm/release/release_test.go
+++ b/pkg/cmd/helm/release/release_test.go
@@ -168,7 +168,7 @@ func TestStepHelmReleaseWithChartPages(t *testing.T) {
 			CLI: runner.OrderedCommands[0].Name + " " + strings.Join(runner.OrderedCommands[0].Args, " "),
 		},
 		fakerunner.FakeResult{
-			CLI: "git sparse-checkout set --no-cone .jx/gitops/source-config.yaml",
+			CLI: "git sparse-checkout set --no-cone jx-requirements.yml .jx/gitops/source-config.yaml",
 		},
 		fakerunner.FakeResult{
 			CLI: "git checkout",
@@ -225,7 +225,7 @@ func TestStepHelmReleaseWithOCIUsingUserName(t *testing.T) {
 			CLI: runner.OrderedCommands[0].Name + " " + strings.Join(runner.OrderedCommands[0].Args, " "),
 		},
 		fakerunner.FakeResult{
-			CLI: "git sparse-checkout set --no-cone .jx/gitops/source-config.yaml",
+			CLI: "git sparse-checkout set --no-cone jx-requirements.yml .jx/gitops/source-config.yaml",
 		},
 		fakerunner.FakeResult{
 			CLI: "git checkout",
@@ -270,7 +270,7 @@ func TestStepHelmReleaseWithOCIUsingRegistryConfig(t *testing.T) {
 			CLI: runner.OrderedCommands[0].Name + " " + strings.Join(runner.OrderedCommands[0].Args, " "),
 		},
 		fakerunner.FakeResult{
-			CLI: "git sparse-checkout set --no-cone .jx/gitops/source-config.yaml",
+			CLI: "git sparse-checkout set --no-cone jx-requirements.yml .jx/gitops/source-config.yaml",
 		},
 		fakerunner.FakeResult{
 			CLI: "git checkout",
@@ -310,7 +310,7 @@ func TestStepHelmReleaseWithOCINoOCILogin(t *testing.T) {
 			CLI: runner.OrderedCommands[0].Name + " " + strings.Join(runner.OrderedCommands[0].Args, " "),
 		},
 		fakerunner.FakeResult{
-			CLI: "git sparse-checkout set --no-cone .jx/gitops/source-config.yaml",
+			CLI: "git sparse-checkout set --no-cone jx-requirements.yml .jx/gitops/source-config.yaml",
 		},
 		fakerunner.FakeResult{
 			CLI: "git checkout",

--- a/pkg/variablefinders/requirements.go
+++ b/pkg/variablefinders/requirements.go
@@ -95,7 +95,11 @@ func GetSettings(g gitclient.Interface, jxClient jxc.Interface, ns, dir, owner, 
 			return nil, "", errors.New("failed to find a dev environment source url on development environment resource")
 		}
 	}
-	clusterDir, err := requirements.PartialCloneClusterRepo(g, gitURL, true, sourceconfigs.SourceConfigFile)
+	combinedConfigFiles := []string{"/" + jxcore.RequirementsConfigFileName, sourceconfigs.SourceConfigFile}
+	if len(combinedConfigFiles) == 0 {
+		return nil, "", errors.New("combined config files are empty")
+	}
+	clusterDir, err := requirements.PartialCloneClusterRepo(g, gitURL, true, combinedConfigFiles...)
 	if err != nil {
 		return nil, "", err
 	}

--- a/pkg/variablefinders/requirements.go
+++ b/pkg/variablefinders/requirements.go
@@ -95,7 +95,7 @@ func GetSettings(g gitclient.Interface, jxClient jxc.Interface, ns, dir, owner, 
 			return nil, "", errors.New("failed to find a dev environment source url on development environment resource")
 		}
 	}
-	combinedConfigFiles := []string{"/" + jxcore.RequirementsConfigFileName, sourceconfigs.SourceConfigFile}
+	combinedConfigFiles := []string{jxcore.RequirementsConfigFileName, sourceconfigs.SourceConfigFile}
 	clusterDir, err := requirements.PartialCloneClusterRepo(g, gitURL, true, combinedConfigFiles...)
 	if err != nil {
 		return nil, "", err

--- a/pkg/variablefinders/requirements.go
+++ b/pkg/variablefinders/requirements.go
@@ -96,9 +96,6 @@ func GetSettings(g gitclient.Interface, jxClient jxc.Interface, ns, dir, owner, 
 		}
 	}
 	combinedConfigFiles := []string{"/" + jxcore.RequirementsConfigFileName, sourceconfigs.SourceConfigFile}
-	if len(combinedConfigFiles) == 0 {
-		return nil, "", errors.New("combined config files are empty")
-	}
 	clusterDir, err := requirements.PartialCloneClusterRepo(g, gitURL, true, combinedConfigFiles...)
 	if err != nil {
 		return nil, "", err


### PR DESCRIPTION
Requirements config file is needed `jx-requirements.yml` as well as `.jx/gitops/source-config.yaml` - add the former when doing a sparse checkout.

Note: tests are failing as only the "clone" step is run: https://github.com/jenkins-x-plugins/jx-gitops/blob/main/pkg/fakerunners/git_cloner.go