### PR TITLE
fix: prune reference to any values files removed from version stream

### DIFF
--- a/pkg/cmd/helmfile/resolve/resolve.go
+++ b/pkg/cmd/helmfile/resolve/resolve.go
@@ -273,6 +273,11 @@ func (o *Options) processHelmfile(helmfile helmfiles.Helmfile) error {
 		return errors.Wrapf(err, "failed to resolve helmfile %s", helmfile)
 	}
 
+	if o.UpdateMode {
+		// let's remove any unused chart repositories
+		removeRedundantRepositories(&helmState)
+	}
+
 	err = yaml2s.SaveFile(helmState, path)
 	if err != nil {
 		return errors.Wrapf(err, "failed to save file %s", helmfile)
@@ -1038,10 +1043,6 @@ func (o *Options) CustomUpgrades(helmstate *state.HelmState) error {
 		}
 	}
 
-	// let's remove any unused jx3 repo
-	removeRedundantRepositories(helmstate)
-
-	// TODO lets remove the jx-labs repository if its no longer referenced...
 	if o.AddEnvironmentPipelines {
 		lighthouseTriggerFile := filepath.Join(o.Dir, ".lighthouse", "jenkins-x", "triggers.yaml")
 		exists, err := files.FileExists(lighthouseTriggerFile)

--- a/pkg/cmd/helmfile/resolve/resolve.go
+++ b/pkg/cmd/helmfile/resolve/resolve.go
@@ -445,6 +445,16 @@ func (o *Options) resolveHelmfile(helmState *state.HelmState, helmfile helmfiles
 				if err != nil {
 					return err
 				}
+				// If release.Chart has changed update related variables
+				if fullChartName != release.Chart {
+					fullChartName = release.Chart
+					parts = strings.Split(fullChartName, "/")
+					chartName = release.Chart
+					if len(parts) > 1 {
+						prefix = parts[0]
+						chartName = parts[1]
+					}
+				}
 			}
 		}
 

--- a/pkg/cmd/helmfile/resolve/resolve.go
+++ b/pkg/cmd/helmfile/resolve/resolve.go
@@ -990,23 +990,6 @@ func (o *Options) CustomUpgrades(helmstate *state.HelmState) error {
 		}
 	}
 
-	// remove jx-labs repository if we have no more charts left using the prefix
-	jxLabsCount := 0
-	for i := range helmstate.Releases {
-		release := &helmstate.Releases[i]
-		if strings.HasPrefix(release.Chart, "jx-labs/") {
-			jxLabsCount++
-		}
-	}
-	if jxLabsCount == 0 {
-		for i := range helmstate.Repositories {
-			if helmstate.Repositories[i].Name == "jx-labs" {
-				helmstate.Repositories = append(helmstate.Repositories[0:i], helmstate.Repositories[i+1:]...)
-				break
-			}
-		}
-	}
-
 	// lets ensure we have the jx-build-controller installed
 	if helmstate.OverrideNamespace == "jx" && isDevCluster(helmstate) {
 		found := false

--- a/pkg/cmd/helmfile/resolve/testdata/custom-env-ingress/expected-jx-helmfile.yaml
+++ b/pkg/cmd/helmfile/resolve/testdata/custom-env-ingress/expected-jx-helmfile.yaml
@@ -21,7 +21,6 @@ releases:
 - chart: jxgh/jxboot-helmfile-resources
   name: jxboot-helmfile-resources
   values:
-  - ../../versionStream/charts/jxgh/jxboot-helmfile-resources/values.yaml.gotmpl
   - jx-values.yaml
 - chart: doesnotexist/bucketrepo
   name: bucketrepo

--- a/pkg/cmd/helmfile/resolve/testdata/helmfile_multi_subfolder/expected-kuberhealthy-helmfile.yaml
+++ b/pkg/cmd/helmfile/resolve/testdata/helmfile_multi_subfolder/expected-kuberhealthy-helmfile.yaml
@@ -14,7 +14,6 @@ releases:
   version: "54"
   name: kuberhealthy
   values:
-  - ../../versionStream/charts/kuberhealthy/kuberhealthy/values.yaml.gotmpl
   - jx-values.yaml
 - chart: jxgh/jx-kh-check
   version: 0.0.78

--- a/pkg/cmd/helmfile/resolve/testdata/helmfile_multi_subfolder/expected-secret-infra-helmfile.yaml
+++ b/pkg/cmd/helmfile/resolve/testdata/helmfile_multi_subfolder/expected-secret-infra-helmfile.yaml
@@ -14,7 +14,6 @@ releases:
   version: 4.0.0
   name: kubernetes-external-secrets
   values:
-  - ../../versionStream/charts/external-secrets/kubernetes-external-secrets/values.yaml.gotmpl
   - jx-values.yaml
 - chart: jxgh/pusher-wave
   version: 0.4.12

--- a/pkg/cmd/helmfile/resolve/testdata/helmfile_subfolder/expected-jx-helmfile.yaml
+++ b/pkg/cmd/helmfile/resolve/testdata/helmfile_subfolder/expected-jx-helmfile.yaml
@@ -12,19 +12,16 @@ releases:
   version: 1.0.64
   name: jxboot-helmfile-resources
   values:
-  - ../../versionStream/charts/jxgh/jxboot-helmfile-resources/values.yaml.gotmpl
   - jx-values.yaml
 - chart: jxgh/jenkins-x-crds
   version: 3.0.7
   name: jenkins-x-crds
   values:
-  - ../../versionStream/charts/jxgh/jenkins-x-crds/values.yaml.gotmpl
   - jx-values.yaml
 - chart: jxgh/jx-pipelines-visualizer
   version: 1.7.1
   name: jx-pipelines-visualizer
   values:
-  - ../../versionStream/charts/jxgh/jx-pipelines-visualizer/values.yaml.gotmpl
   - jx-values.yaml
 - chart: jxgh/jx-preview
   version: 0.0.183
@@ -43,7 +40,6 @@ releases:
   version: 0.1.65
   name: bucketrepo
   values:
-  - ../../versionStream/charts/jxgh/bucketrepo/values.yaml.gotmpl
   - jx-values.yaml
 - chart: jxgh/jx-build-controller
   version: 0.3.3
@@ -59,7 +55,6 @@ releases:
   version: 0.0.56
   name: health-checks-jx
   values:
-  - ../../versionStream/charts/jxgh/health-checks-jx/values.yaml.gotmpl
   - jx-values.yaml
 templates: {}
 renderedvalues: {}

--- a/pkg/cmd/helmfile/resolve/testdata/helmfile_subfolder/expected-secret-infra-helmfile.yaml
+++ b/pkg/cmd/helmfile/resolve/testdata/helmfile_subfolder/expected-secret-infra-helmfile.yaml
@@ -14,7 +14,6 @@ releases:
   version: 4.0.0
   name: kubernetes-external-secrets
   values:
-  - ../../versionStream/charts/external-secrets/kubernetes-external-secrets/values.yaml.gotmpl
   - jx-values.yaml
 - chart: jxgh/pusher-wave
   version: 0.4.12

--- a/pkg/cmd/helmfile/resolve/testdata/local-secrets/expected-jx-helmfile.yaml
+++ b/pkg/cmd/helmfile/resolve/testdata/local-secrets/expected-jx-helmfile.yaml
@@ -25,7 +25,6 @@ releases:
 - chart: jxgh/jenkins-x-crds
   name: jenkins-x-crds
   values:
-  - ../../versionStream/charts/jxgh/jenkins-x-crds/values.yaml.gotmpl
   - jx-values.yaml
 - chart: jxgh/local-external-secrets
   name: local-external-secrets

--- a/pkg/cmd/helmfile/resolve/testdata/remote-chart/expected-nginx-helmfile.yaml
+++ b/pkg/cmd/helmfile/resolve/testdata/remote-chart/expected-nginx-helmfile.yaml
@@ -7,6 +7,5 @@ releases:
   - chart: ingress-nginx/ingress-nginx
     name: nginx-ingress
     values:
-      - ../../versionStream/charts/ingress-nginx/values.yaml.gotmpl
 templates: {}
 renderedvalues: {}

--- a/pkg/cmd/helmfile/resolve/testdata/remote-cluster/expected-nginx-helmfile.yaml
+++ b/pkg/cmd/helmfile/resolve/testdata/remote-cluster/expected-nginx-helmfile.yaml
@@ -11,7 +11,6 @@ releases:
 - chart: ingress-nginx/ingress-nginx
   name: nginx-ingress
   values:
-  - ../../versionStream/charts/ingress-nginx/ingress-nginx/values.yaml.gotmpl
   - jx-values.yaml
 templates: {}
 renderedvalues: {}


### PR DESCRIPTION
This is useful when changing from values.yaml to values.yaml.gotmpl or when changeing repository for chart and moving values file along