### PR TITLE
chore: Update helmfile version

### DIFF
--- a/pkg/plugins/versions.go
+++ b/pkg/plugins/versions.go
@@ -25,7 +25,7 @@ const (
 	HelmVersion = "3.15.1"
 
 	// HelmfileVersion the default version of helmfile to use
-	HelmfileVersion = "0.149.0"
+	HelmfileVersion = "0.165.0"
 
 	// KptVersion the default version of kpt to use
 	KptVersion = "1.0.0-beta.45"


### PR DESCRIPTION
Helmfile version in jx-promote and jx-gitops are not matching 

https://github.com/jenkins-x-plugins/jx-promote/blob/4d9a914b6d5fdd5b3afc3345d5ab08c84d0d512e/go.mod#L8

https://github.com/jenkins-x-plugins/jx-gitops/blob/2cf70da50c5972e842c2d67430aaeb0abf511e4b/pkg/plugins/versions.go#L28

This is causing the PR created by jx-promote plugin to fail