### PR TITLE
chore: Bump helm and helmfile versions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/google/go-cmp v0.7.0
 	github.com/google/uuid v1.6.0
 	github.com/h2non/gock v1.0.9
-	github.com/helmfile/helmfile v0.165.0
+	github.com/helmfile/helmfile v1.1.0
 	github.com/imdario/mergo v0.3.16
 	github.com/jenkins-x-plugins/jx-charter v0.0.30
 	github.com/jenkins-x/go-scm v1.15.1

--- a/pkg/plugins/versions.go
+++ b/pkg/plugins/versions.go
@@ -22,10 +22,10 @@ const (
 	KustomizePluginName = "kustomize"
 
 	// HelmVersion the default version of helm to use
-	HelmVersion = "3.15.1"
+	HelmVersion = "3.18.0"
 
 	// HelmfileVersion the default version of helmfile to use
-	HelmfileVersion = "0.165.0"
+	HelmfileVersion = "1.1.0"
 
 	// KptVersion the default version of kpt to use
 	KptVersion = "1.0.0-beta.45"


### PR DESCRIPTION
Upgrades the bundled Helm binary from 3.15.1 → 3.18.0 and Helmfile from 0.165.0 → 1.1.0.

We hit a blocking issue deploying aws-ebs-csi-driver chart v2.40.0+ via helmfile. The chart introduced a values.schema.json with additionalProperties: false, which causes schema validation to fail because helmfile passes its own internal values files (containing jxRequirements) to helm as --values. Helm's schema validator rejects the unknown keys.

Error: values don't meet the specifications of the schema(s):
 - (root): Additional property jxRequirements is not allowed

This blocks us from upgrading aws-ebs-csi-driver beyond v2.39.3, and AWS requires EBS CSI driver chart ≥ 2.50.0 before upgrading EKS to 1.34 (due to the VolumeAttributesClass API graduating to GA).

What we tried (on helmfile 0.165.0)

| Approach                                              | Result |
|------------------------------------------------------|--------|
| helmDefaults.args: ["--skip-schema-validation"]      | Broke `helm fetch` for other charts (flag unsupported on fetch) |
| skipSchemaValidation: true per-release               | `field skipSchemaValidation not found in type state.ReleaseSpec` — not supported in 0.165.0 |
| disableValidation: true per-release                  | Maps to `--disable-validation` (K8s API validation), not schema validation |


The fix:

Helmfile added per-release skipSchemaValidation support in [PR #1935](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) (Feb 2025), first available in v1.0.0-rc.12 and stable in v1.0.0 (Apr 2025).

With this upgrade, we can use:

releases:
  - name: aws-ebs-csi-driver
    chart: aws-ebs-csi-driver/aws-ebs-csi-driver
    version: 2.62.0
    skipSchemaValidation: true

This passes --skip-schema-validation to helm install/upgrade/template, which skips the [values.schema.json](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) check while keeping all other validations intact.

Why v1.1.0 specifically

| Version | Helm bundled | Notes |
|---------|--------------|-------|
| v1.0.0 | 3.17.3 | First stable with `skipSchemaValidation`, but deprecated by maintainers |
| v1.1.0 | 3.18.0 | Recommended stable release, minor Helm bump from 3.15.1 |