### PR TITLE
fix(update): error ignore flag in kpt dirs; update kpt fix image

### DIFF
--- a/pkg/cmd/kpt/update/update.go
+++ b/pkg/cmd/kpt/update/update.go
@@ -190,6 +190,10 @@ func (o *Options) Run() error {
 				if apiVersion != "kpt.dev/v1" {
 					err := o.upgradeKptPkg(path, bin, apiVersion)
 					if err != nil {
+						if o.IgnoreYamlContentError && strings.Contains(err.Error(), "yaml: did not find expected node content") {
+							log.Logger().Warnf("ignoring kpt package %s as it contains YAML that cannot be parsed: %s", rel, err.Error())
+							return nil
+						}
 						return err
 					}
 					node, err = kyaml.ReadFile(path)
@@ -357,7 +361,7 @@ func (o *Options) LoadOverrideStrategies() (map[string]string, error) {
 
 func (o *Options) upgradeKptPkg(kptfilePath, bin, upgradeFromAPIVersion string) error {
 	dir := filepath.Dir(kptfilePath)
-	args := []string{"fn", "eval", "--image", "gcr.io/kpt-fn/fix:v0.2", "--truncate-output=false", "--match-api-version", upgradeFromAPIVersion}
+	args := []string{"fn", "eval", "--image", "ghcr.io/kptdev/krm-functions-catalog/fix:ad0c3fe", "--truncate-output=false", "--match-api-version", upgradeFromAPIVersion}
 	c := &cmdrunner.Command{
 		Dir:  dir,
 		Name: bin,

--- a/pkg/cmd/kpt/update/update_test.go
+++ b/pkg/cmd/kpt/update/update_test.go
@@ -4,10 +4,13 @@ package update_test
 import (
 	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/jenkins-x-plugins/jx-gitops/pkg/cmd/kpt/update"
+	"github.com/jenkins-x/jx-helpers/v3/pkg/cmdrunner"
 	"github.com/jenkins-x/jx-helpers/v3/pkg/cmdrunner/fakerunner"
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 )
 
@@ -123,6 +126,76 @@ func TestUpdateKptFilterNotMatching(t *testing.T) {
 			CLI: "git status -s",
 		},
 	)
+}
+
+// failOnFnEval returns a yaml content error for the `kpt fn eval` command that migrates
+// old-format Kptfiles, mimicking a package containing YAML that kpt cannot parse (e.g. Helm templates)
+func failOnFnEval(c *cmdrunner.Command) (string, error) {
+	if strings.Contains(cmdrunner.CLI(c), "fn eval") {
+		return "", errors.New("MalformedYAMLError: yaml: did not find expected node content")
+	}
+	return "", nil
+}
+
+func TestUpdateKptUpgradesLegacyKptfileWithPinnedImage(t *testing.T) {
+	sourceDir := "testdata"
+
+	_, uk := update.NewCmdKptUpdate()
+	uk.KptBinary = "kpt"
+
+	runner := &fakerunner.FakeRunner{}
+	uk.CommandRunner = runner.Run
+	uk.Dir = sourceDir
+	// leaving Version empty triggers the Kptfile format upgrade via `kpt fn eval`
+
+	err := uk.Run()
+	require.NoError(t, err, "failed to run update kpt")
+
+	// the testdata Kptfiles use apiVersion kpt.dev/v1alpha1 so each is migrated via `kpt fn eval`
+	var fnEvalCommands []string
+	for _, c := range runner.OrderedCommands {
+		cli := cmdrunner.CLI(c)
+		if strings.Contains(cli, "fn eval") {
+			fnEvalCommands = append(fnEvalCommands, cli)
+		}
+	}
+	require.NotEmpty(t, fnEvalCommands, "expected at least one `kpt fn eval` command to migrate legacy Kptfiles")
+	for _, cli := range fnEvalCommands {
+		require.Contains(t, cli, "--image ghcr.io/kptdev/krm-functions-catalog/fix:ad0c3fe",
+			"fn eval must use the pinned krm-functions-catalog fix image")
+	}
+}
+
+func TestUpdateKptIgnoreYamlErrorSkipsPackage(t *testing.T) {
+	sourceDir := "testdata"
+
+	_, uk := update.NewCmdKptUpdate()
+	uk.KptBinary = "kpt"
+
+	runner := &fakerunner.FakeRunner{CommandRunner: failOnFnEval}
+	uk.CommandRunner = runner.Run
+	uk.Dir = sourceDir
+	// leaving Version empty triggers the Kptfile format upgrade via `kpt fn eval`
+	uk.IgnoreYamlContentError = true
+
+	err := uk.Run()
+	require.NoError(t, err, "should ignore the yaml content error when --ignore-yaml-error is set")
+}
+
+func TestUpdateKptYamlErrorWithoutFlagFails(t *testing.T) {
+	sourceDir := "testdata"
+
+	_, uk := update.NewCmdKptUpdate()
+	uk.KptBinary = "kpt"
+
+	runner := &fakerunner.FakeRunner{CommandRunner: failOnFnEval}
+	uk.CommandRunner = runner.Run
+	uk.Dir = sourceDir
+	// leaving Version empty triggers the Kptfile format upgrade via `kpt fn eval`
+
+	err := uk.Run()
+	require.Error(t, err, "should surface the yaml content error when --ignore-yaml-error is not set")
+	require.Contains(t, err.Error(), "yaml: did not find expected node content")
 }
 
 func TestOptions_loadOverrideStrategies(t *testing.T) {


### PR DESCRIPTION
### Changes
* update image used to run `kpt fn eval fix` in `upgradeKptPkg`
* Use `IgnoreYamlContentError` when processing kpt directories

### Context

Fix for issue found here https://github.com/jenkins-x/jx3-pipeline-catalog/pull/1839#issuecomment-4834180992

`jx gitops upgrade --ignore-yaml-error` fails when processing new kpt directories. The `fix` container published by kpt at`gcr.io/kpt-fn/fix:v0.2` is replaced by `ghcr.io/kptdev/krm-functions-catalog/fix:ad0c3fe`.

`fix` has been archived by the kpt project, so I've added a TODO to look at an alternative. 

Also add an additional `IgnoreYamlContentError` check when processing kpt directories, which swallowed this error.